### PR TITLE
Tie in the VV mapping functions including gap mapper and update missi…

### DIFF
--- a/VariantFormatter/formatter.py
+++ b/VariantFormatter/formatter.py
@@ -339,9 +339,14 @@ def gap_checker(hgvs_transcript, hgvs_genomic, un_norm_hgvs_genomic, genome_buil
     hgvs_version = vfo.hgvsVersion
     
     # Check for gapping
-    checked = gapGenes.compensate_g_to_t(hgvs_transcript, hgvs_genomic, 
-                                        un_norm_hgvs_genomic, vm, hn, rhn, 
-                                        genome_build, hdp, hp, sf, hgvs_version, vfo)
+    checked = gapGenes.compensate_g_to_t(hgvs_transcript,
+                                         hgvs_genomic,
+                                         vm,
+                                         hn,
+                                         rhn,
+                                         genome_build,
+                                         hdp,
+                                         vfo)
 
     return checked
     

--- a/VariantFormatter/gapGenes.py
+++ b/VariantFormatter/gapGenes.py
@@ -3,16 +3,19 @@
 # Import python modules
 # from distutils.version import StrictVersion
 import re
-import copy
+# import copy
 import vvhgvs.exceptions
 import vvhgvs.assemblymapper
 import vvhgvs.variantmapper
-import VariantFormatter
 
 # VV
 import VariantValidator
 import VariantValidator.modules.seq_data as seq_data
-import VariantValidator.modules.hgvs_utils as va_H2V
+# import VariantValidator.modules.hgvs_utils as va_H2V
+import VariantValidator.modules.gapped_mapping
+from VariantValidator.modules.variant import Variant
+# vval = VariantValidator.Validator()
+
 
 """
 Internal function that returns True if gene symbol is blacklisted and False if not
@@ -33,8 +36,14 @@ hgvs <= 1.1.3
 """
 
 
-def compensate_g_to_t(hgvs_tx, hgvs_genomic, un_norm_hgvs_genomic, vm,
-                        hn, reverse_normalizer, primary_assembly, hdp, hp, sf, hgvs_version, vfo):
+def compensate_g_to_t(hgvs_tx,
+                      hgvs_genomic,
+                      vm,
+                      hn,
+                      reverse_normalizer,
+                      primary_assembly,
+                      hdp,
+                      vfo):
 
     # Not required in these instances
     if re.match('ENST', hgvs_tx.ac): # or (StrictVersion(str(hgvs_version)) > StrictVersion('1.1.3') is True):
@@ -54,38 +63,81 @@ def compensate_g_to_t(hgvs_tx, hgvs_genomic, un_norm_hgvs_genomic, vm,
                                                 reverse_normalizer, hdp, vm, vfo)
             hgvs_tx_returns = [normalized_tx, False, None, None, None]
         else:
-            # At this stage, we know that:
-            # the gene is on the gap list
-            # the hgvs version is <= 1.1.3
-            # The requested transcript set is RefSeq
-            gap_compensated_tx = g_to_t_compensation_code(hgvs_tx, hgvs_genomic,
-                                                                un_norm_hgvs_genomic, 
-                                                                vm, hn, 
-                                                                reverse_normalizer,
-                                                                primary_assembly,
-                                                                hdp, hp, sf, vfo)
-            # except Exception as e:
-            #     import sys
-            #     import traceback
-            #     exc_type, exc_value, last_traceback = sys.exc_info()
-            #     te = traceback.format_exc()
-            #     tbk = [str(exc_type), str(exc_value), str(te)]
-            #     er = str('\n'.join(tbk))
 
-            if gap_compensated_tx[1] is False:
+            """
+            Code now modified to use native VV gap mapper
+            """
+
+            # VV functions require evm instances
+            no_norm_evm = vvhgvs.assemblymapper.AssemblyMapper(hdp,
+                                                               assembly_name=primary_assembly,
+                                                               alt_aln_method="splign",  # Only RefSeq should be here!!!
+                                                               normalize=False,
+                                                               replace_reference=True
+                                                               )
+            evm = vvhgvs.assemblymapper.AssemblyMapper(hdp,
+                                                       assembly_name=primary_assembly,
+                                                       alt_aln_method="splign",  # Only RefSeq should be here!!!
+                                                       normalize=True,
+                                                       replace_reference=True
+                                                       )
+
+            # Set validator attributes
+            vfo.select_transcripts = 'all'
+            vfo.alt_aln_method = 'splign'
+
+            # Set variant specific attributes
+            variant = Variant(str(hgvs_genomic))
+            variant.hgvs_genomic = hgvs_genomic
+            variant.reverse_normalizer = reverse_normalizer
+            variant.hn = hn
+            variant.evm = evm
+            variant.no_norm_evm = no_norm_evm
+            variant.vm = vm
+            variant.primary_assembly = primary_assembly
+            variant.post_format_conversion = hgvs_genomic
+            gap_mapper = VariantValidator.modules.gapped_mapping.GapMapper(variant, vfo)
+            data, nw_rel_var = gap_mapper.gapped_g_to_c([str(hgvs_tx)], select_transcripts_dict={})
+
+            # Populate output list
+            gap_compensated_tx_2 = []
+            gap_compensated_tx_2.append(nw_rel_var[0])
+            if "does not represent a true variant" in data["gapped_alignment_warning"] \
+                    or "may be an artefact of" in data["gapped_alignment_warning"]:
+                gap_compensated_tx_2.append(True)
+            else:
+                gap_compensated_tx_2.append(False)
+            try:
+                if data["disparity_deletion_in"][0] == 'transcript':
+                    corrective_action_taken = 'Automap has deleted ' + str(
+                        data["disparity_deletion_in"][1][0]) + ' bp from chromosomal reference sequence ' + str(
+                        hgvs_genomic.ac) + ' to ensure perfect alignment with transcript reference_sequence'
+                if data["disparity_deletion_in"][0] == 'chromosome':
+                    corrective_action_taken = 'Automap has added ' + str(
+                        data["disparity_deletion_in"][1][0]) + ' bp to chromosomal reference sequence ' + str(
+                        hgvs_genomic.ac) + ' to ensure perfect alignment with transcript reference_sequence '
+                gap_compensated_tx_2.append(corrective_action_taken)
+            except Exception:
+                gap_compensated_tx_2.append(None)
+            gap_compensated_tx_2.append(data["gapped_alignment_warning"].replace("the transcripts listed below",
+                                                                                 nw_rel_var[0].ac))
+            gap_compensated_tx_2.append(data["auto_info"].replace("\n", ""))
+
+            if gap_compensated_tx_2[1] is False:
                 refresh_hgvs_tx = fully_normalize(hgvs_tx, hgvs_genomic, hn,
                                                 reverse_normalizer, hdp, vm, vfo)
-                gap_compensated_tx[0] = refresh_hgvs_tx                                         
-            hgvs_tx_returns = gap_compensated_tx
-                        
-    
+                gap_compensated_tx_2[0] = refresh_hgvs_tx
+            hgvs_tx_returns = gap_compensated_tx_2
+
+    # Create response dictionary for gap mapping output
     hgvs_tx_dict = {'hgvs_transcript': hgvs_tx_returns[0],
-                    'position_lock': hgvs_tx_returns[1],
+                    # 'position_lock': hgvs_tx_returns[1],
                     'gapped_alignment_warning': hgvs_tx_returns[3],
                     'corrective_action': hgvs_tx_returns[2],
                     'gap_position': hgvs_tx_returns[-1],
                     'transcript_accession': hgvs_tx_returns[0].ac
                     }
+
     return hgvs_tx_dict
 
 
@@ -132,1010 +184,6 @@ def fully_normalize(hgvs_tx, hgvs_genomic, hn, reverse_normalizer, hdp, vm, vfo)
         
     return hgvs_tx
 
-
-"""
-Gap compensation code from genome to transcript
-
-Source is VariantValidator
-
-Requires an un-normalized genomic variant for stashing if available
-
-Also requres a hgvs_genomic and tx id
-"""
-                        
-
-def g_to_t_compensation_code(hgvs_tx, hgvs_genomic, un_norm_hgvs_genomic, vm, hn,
-                                reverse_normalizer, primary_assembly, hdp, hp, sf, vfo):
-
-    # Ensure hgvs_tx is good to go
-    try:
-        hn.normalize(hgvs_tx)
-    except vvhgvs.exceptions.HGVSInvalidVariantError as e:
-        if 'insertion length must be 1' in str(e):
-            hgvs_tx_anew = '%s:%s.%sdelins%s' % (hgvs_tx.ac, hgvs_tx.type, str(hgvs_tx.posedit.pos),
-                                                 hgvs_tx.posedit.edit.alt)
-            hgvs_tx = hp.parse_hgvs_variant(hgvs_tx_anew)
-    except vvhgvs.exceptions.HGVSUnsupportedOperationError:
-        pass
-
-    """
-    Gap aware projection from g. to c.
-    """
-
-    # Create mappers: has to be inline because requires primary_assembly and alt_aln_method
-    alt_aln_method = 'splign'
-    no_norm_evm = vvhgvs.assemblymapper.AssemblyMapper(hdp,
-                                                     assembly_name=primary_assembly,
-                                                     alt_aln_method=alt_aln_method, # Only RefSeq should be here!!!
-                                                     normalize=False,
-                                                     replace_reference=True
-                                                     )
-    evm = vvhgvs.assemblymapper.AssemblyMapper(hdp,
-                                                     assembly_name=primary_assembly,
-                                                     alt_aln_method=alt_aln_method, # Only RefSeq should be here!!!
-                                                     normalize=True,
-                                                     replace_reference=True
-                                                     )
-
-    nr_vm = vvhgvs.variantmapper.VariantMapper(hdp, replace_reference=False)
-
-    utilise_gap_code = True
-    automap = ''
-    
-    # Set variables for problem specific warnings
-    gapped_alignment_warning = None
-    corrective_action_taken = None
-    gapped_transcripts = ''
-    auto_info = None
-    
-    # Set variables
-    stash_input = hgvs_genomic
-    hgvs_genomic_variant = hgvs_genomic
-    # Reverse normalize hgvs_genomic_variant: NOTE will replace ref
-    reverse_normalized_hgvs_genomic = reverse_normalizer.normalize(hgvs_genomic_variant)
-    hgvs_genomic_5pr = copy.deepcopy(reverse_normalized_hgvs_genomic)
-
-    # Create a pseudo VCF so that normalization can be applied and a delins can be generated
-    vcf_dict = va_H2V.hgvs2vcf(reverse_normalized_hgvs_genomic, primary_assembly, reverse_normalizer, sf)
-    chr = vcf_dict['chr']
-    pos = vcf_dict['pos']
-    ref = vcf_dict['ref']
-    alt = vcf_dict['alt']
-
-    # Generate an end position
-    end = str(int(pos) + len(ref) - 1)
-    pos = str(pos)
-
-    # take a look at the input genomic variant for potential base salvage
-    stash_ac = vcf_dict['chr']
-    stash_pos = int(vcf_dict['pos'])
-    stash_ref = vcf_dict['ref']
-    stash_alt = vcf_dict['alt']
-    stash_end = end
-    # Re-Analyse genomic positions
-    if re.match('NG_', str(stash_input)):
-        c = hgvs_tx
-        try:
-            c.posedit.edit.ref = c.posedit.edit.ref.upper()
-        except Exception:
-            pass
-        try:
-            c.posedit.edit.alt = c.posedit.edit.alt.upper()
-        except Exception:
-            pass
-        stash_input = vfo.myevm_t_to_g(c, no_norm_evm, primary_assembly, hn)
-    if re.match('NC_', str(stash_input)) or re.match('NT_', str(stash_input)) or re.match('NW_',
-                                                                                          str(
-                                                                                                  stash_input)):
-        try:
-            hgvs_stash = hp.parse_hgvs_variant(stash_input)
-        except:
-            hgvs_stash = stash_input
-        try:
-            hgvs_stash.posedit.edit.ref = hgvs_stash.posedit.edit.ref.upper()
-        except Exception:
-            pass
-        try:
-            hgvs_stash.posedit.edit.alt = hgvs_stash.posedit.edit.alt.upper()
-        except Exception:
-            pass
-
-        stash_ac = hgvs_stash.ac
-        # MAKE A NO NORM HGVS2VCF
-        stash_dict = va_H2V.pos_lock_hgvs2vcf(hgvs_stash, primary_assembly, reverse_normalizer, sf)
-
-        stash_ac = hgvs_stash.ac
-        stash_pos = int(stash_dict['pos'])
-        stash_ref = stash_dict['ref']
-        stash_alt = stash_dict['alt']
-        # Generate an end position
-        stash_end = str(stash_pos + len(stash_ref) - 1)
-
-    # Store a not real deletion insertion
-    stored_hgvs_not_delins = hp.parse_hgvs_variant(str(
-        hgvs_genomic_5pr.ac) + ':' + hgvs_genomic_5pr.type + '.' + pos + '_' + end + 'del' + ref + 'ins' + alt)
-    stash_hgvs_not_delins = hp.parse_hgvs_variant(
-        stash_ac + ':' + hgvs_genomic_5pr.type + '.' + str(
-            stash_pos) + '_' + stash_end + 'del' + stash_ref + 'ins' + stash_alt)
-
-    # Set non-valid caution to false
-    non_valid_caution = 'false'
-
-    # Store the current hgvs:c. description
-    saved_hgvs_coding = hgvs_tx
-
-    # Get orientation of the gene wrt genome and a list of exons mapped to the genome
-    ori = vfo.tx_exons(saved_hgvs_coding.ac, hgvs_genomic.ac, alt_aln_method)
-    orientation = int(ori[0]['alt_strand'])
-    intronic_variant = 'false'
-
-    if orientation == -1:
-        # position genomic at its most 5 prime position
-        try:
-            query_genomic = reverse_normalizer.normalize(hgvs_genomic)
-        except:
-            query_genomic = hgvs_genomic
-        # Map to the transcript ant test for movement
-        try:
-            hgvs_seek_var = evm.g_to_t(query_genomic, saved_hgvs_coding.ac)
-        except vvhgvs.exceptions.HGVSError as e:
-            hgvs_seek_var = saved_hgvs_coding
-        else:
-            seek_var = str(hgvs_seek_var)
-            seek_ac = str(hgvs_seek_var.ac)
-        if (hgvs_seek_var.posedit.pos.start.base + hgvs_seek_var.posedit.pos.start.offset) > (
-                saved_hgvs_coding.posedit.pos.start.base + saved_hgvs_coding.posedit.pos.start.offset) and (
-                hgvs_seek_var.posedit.pos.end.base + hgvs_seek_var.posedit.pos.end.offset) > (
-                saved_hgvs_coding.posedit.pos.end.base + saved_hgvs_coding.posedit.pos.end.offset):
-            pass
-        else:
-            hgvs_seek_var = saved_hgvs_coding
-
-    elif orientation != -1:
-        # position genomic at its most 3 prime position
-        try:
-            query_genomic = hn.normalize(hgvs_genomic)
-        except:
-            query_genomic = hgvs_genomic
-    # Map to the transcript and test for movement
-    try:
-        hgvs_seek_var = evm.g_to_t(query_genomic, saved_hgvs_coding.ac)
-    except vvhgvs.exceptions.HGVSError as e:
-        hgvs_seek_var = saved_hgvs_coding
-    else:
-        #seek_var = str(hgvs_seek_var)
-        #seek_ac = str(hgvs_seek_var.ac)
-        if (hgvs_seek_var.posedit.pos.start.base + hgvs_seek_var.posedit.pos.start.offset) > (
-                saved_hgvs_coding.posedit.pos.start.base + saved_hgvs_coding.posedit.pos.start.offset) and (
-                hgvs_seek_var.posedit.pos.end.base + hgvs_seek_var.posedit.pos.end.offset) > (
-                saved_hgvs_coding.posedit.pos.end.base + saved_hgvs_coding.posedit.pos.end.offset):
-            pass
-        else:
-            hgvs_seek_var = saved_hgvs_coding
-
-    try:
-        intron_test = hn.normalize(hgvs_seek_var)
-    except vvhgvs.exceptions.HGVSUnsupportedOperationError as e:
-        error = str(e)
-        if re.match('Normalization of intronic variants is not supported', error) or re.match(
-                'Unsupported normalization of variants spanning the exon-intron boundary',
-                error):
-            if re.match(
-                    'Unsupported normalization of variants spanning the exon-intron boundary',
-                    error):
-                intronic_variant = 'hard_fail'
-            else:
-                # Double check to see whether the variant is actually intronic?
-                for exon in ori:
-                    genomic_start = int(exon['alt_start_i'])
-                    genomic_end = int(exon['alt_end_i'])
-                    if (
-                            hgvs_genomic_5pr.posedit.pos.start.base > genomic_start and hgvs_genomic_5pr.posedit.pos.start.base <= genomic_end) and (
-                            hgvs_genomic_5pr.posedit.pos.end.base > genomic_start and hgvs_genomic_5pr.posedit.pos.end.base <= genomic_end):
-                        intronic_variant = 'false'
-                        break
-                    else:
-                        intronic_variant = 'true'
-
-    if intronic_variant != 'hard_fail':
-        if re.search('\d+\+', str(hgvs_seek_var.posedit.pos)) or re.search('\d+\-', str(
-                hgvs_seek_var.posedit.pos)) or re.search('\*\d+\+', str(
-            hgvs_seek_var.posedit.pos)) or re.search('\*\d+\-',
-                                                     str(hgvs_seek_var.posedit.pos)):
-            # Double check to see whether the variant is actually intronic?
-            for exon in ori:
-                genomic_start = int(exon['alt_start_i'])
-                genomic_end = int(exon['alt_end_i'])
-                if (
-                        hgvs_genomic_5pr.posedit.pos.start.base > genomic_start and hgvs_genomic_5pr.posedit.pos.start.base <= genomic_end) and (
-                        hgvs_genomic_5pr.posedit.pos.end.base > genomic_start and hgvs_genomic_5pr.posedit.pos.end.base <= genomic_end):
-                    intronic_variant = 'false'
-                    break
-                else:
-                    intronic_variant = 'true'
-
-    if re.search('\d+\+', str(hgvs_seek_var.posedit.pos)) or re.search('\d+\-', str(
-            hgvs_seek_var.posedit.pos)) or re.search('\*\d+\+', str(
-        hgvs_seek_var.posedit.pos)) or re.search('\*\d+\-', str(hgvs_seek_var.posedit.pos)):
-        # Double check to see whether the variant is actually intronic?
-        for exon in ori:
-            genomic_start = int(exon['alt_start_i'])
-            genomic_end = int(exon['alt_end_i'])
-            if (
-                    hgvs_genomic_5pr.posedit.pos.start.base > genomic_start and hgvs_genomic_5pr.posedit.pos.start.base <= genomic_end) and (
-                    hgvs_genomic_5pr.posedit.pos.end.base > genomic_start and hgvs_genomic_5pr.posedit.pos.end.base <= genomic_end):
-                intronic_variant = 'false'
-                break
-            else:
-                intronic_variant = 'true'
-
-    # If exonic, process
-    if intronic_variant != 'true':
-        # map form reverse normalized g. to c.
-        hgvs_from_5n_g = no_norm_evm.g_to_t(hgvs_genomic_5pr, saved_hgvs_coding.ac)
-
-        # Attempt to find gaps in reference sequence by catching disparity in genome length and overlapping transcript lengths
-        disparity_deletion_in = ['false', 'false']
-        if stored_hgvs_not_delins != '':
-            # Refresh hgvs_not_delins from stored_hgvs_not_delins
-            hgvs_not_delins = copy.deepcopy(stored_hgvs_not_delins)
-            # This test will only occur in dup of single base, insertion or substitution
-            if not re.search('_', str(hgvs_not_delins.posedit.pos)):
-                if re.search('dup', hgvs_genomic_5pr.posedit.edit.type) or re.search('ins',
-                                                                                     hgvs_genomic_5pr.posedit.edit.type):
-                    # For gap in chr, map to t. - but becaouse we have pushed to 5 prime by norm, add 1 to end pos
-                    plussed_hgvs_not_delins = copy.deepcopy(hgvs_not_delins)
-                    plussed_hgvs_not_delins.posedit.pos.end.base = plussed_hgvs_not_delins.posedit.pos.end.base + 1
-                    plussed_hgvs_not_delins.posedit.edit.ref = ''
-                    transcript_variant = no_norm_evm.g_to_t(plussed_hgvs_not_delins,
-                                                            str(saved_hgvs_coding.ac))
-                    if ((
-                            transcript_variant.posedit.pos.end.base - transcript_variant.posedit.pos.start.base) > (
-                            hgvs_genomic_5pr.posedit.pos.end.base - hgvs_genomic_5pr.posedit.pos.start.base)):
-                        if re.search('dup', str(hgvs_genomic_5pr.posedit.edit)):
-                            hgvs_not_delins.posedit.pos.end.base = hgvs_not_delins.posedit.pos.start.base + 1
-                            start = hgvs_not_delins.posedit.pos.start.base - 1
-                            end = hgvs_not_delins.posedit.pos.end.base
-                            ref_bases = sf.fetch_seq(str(hgvs_not_delins.ac), start, end)
-                            hgvs_not_delins.posedit.edit.ref = ref_bases
-                            hgvs_not_delins.posedit.edit.alt = ref_bases[
-                                                               :1] + hgvs_not_delins.posedit.edit.alt[
-                                                                     1:] + ref_bases[1:]
-                        elif re.search('ins', str(hgvs_genomic_5pr.posedit.edit)) and re.search(
-                                'del', str(hgvs_genomic_5pr.posedit.edit)):
-                            hgvs_not_delins.posedit.pos.end.base = hgvs_not_delins.posedit.pos.start.base + 1
-                        elif re.search('ins',
-                                       str(hgvs_genomic_5pr.posedit.edit)) and not re.search(
-                            'del', str(hgvs_genomic_5pr.posedit.edit)):
-                            hgvs_not_delins.posedit.pos.end.base = hgvs_not_delins.posedit.pos.start.base + 1
-                            start = hgvs_not_delins.posedit.pos.start.base - 1
-                            end = hgvs_not_delins.posedit.pos.end.base
-                            ref_bases = sf.fetch_seq(str(hgvs_not_delins.ac), start, end)
-                            hgvs_not_delins.posedit.edit.ref = ref_bases
-                            hgvs_not_delins.posedit.edit.alt = ref_bases[
-                                                               :1] + hgvs_not_delins.posedit.edit.alt[
-                                                                     1:] + ref_bases[1:]
-                    else:
-                        if re.search('dup', str(hgvs_genomic_5pr.posedit.edit)):
-                            hgvs_not_delins.posedit.pos.end.base = hgvs_not_delins.posedit.pos.start.base + 1
-                            start = hgvs_not_delins.posedit.pos.start.base - 1
-                            end = hgvs_not_delins.posedit.pos.end.base
-                            ref_bases = sf.fetch_seq(str(hgvs_not_delins.ac), start, end)
-                            hgvs_not_delins.posedit.edit.ref = ref_bases
-                            hgvs_not_delins.posedit.edit.alt = ref_bases[
-                                                               :1] + hgvs_not_delins.posedit.edit.alt[
-                                                                     1:] + ref_bases[1:]
-                        elif re.search('ins', str(hgvs_genomic_5pr.posedit.edit)) and re.search(
-                                'del', str(hgvs_genomic_5pr.posedit.edit)):
-                            hgvs_not_delins.posedit.pos.end.base = hgvs_not_delins.posedit.pos.start.base + 1
-                        elif re.search('ins',
-                                       str(hgvs_genomic_5pr.posedit.edit)) and not re.search(
-                            'del', str(hgvs_genomic_5pr.posedit.edit)):
-                            hgvs_not_delins.posedit.pos.end.base = hgvs_not_delins.posedit.pos.start.base + 1
-                            start = hgvs_not_delins.posedit.pos.start.base - 1
-                            end = hgvs_not_delins.posedit.pos.end.base
-                            ref_bases = sf.fetch_seq(str(hgvs_not_delins.ac), start, end)
-                            hgvs_not_delins.posedit.edit.ref = ref_bases
-                            hgvs_not_delins.posedit.edit.alt = ref_bases[
-                                                               :1] + hgvs_not_delins.posedit.edit.alt[
-                                                                     1:] + ref_bases[1:]
-                else:
-                    pass
-            else:
-                pass
-
-            try:
-                tx_hgvs_not_delins = no_norm_evm.g_to_n(hgvs_not_delins, saved_hgvs_coding.ac)
-            except vvhgvs.exceptions.HGVSInvalidIntervalError:
-                tx_hgvs_not_delins = no_norm_evm.g_to_n(hgvs_genomic_5pr, saved_hgvs_coding.ac)
-            except vvhgvs.exceptions.HGVSError:
-                if str(e) == 'start or end or both are beyond the bounds of transcript record':
-                    tx_hgvs_not_delins = saved_hgvs_coding
-
-            # Create normalized version of tx_hgvs_not_delins
-            rn_tx_hgvs_not_delins = copy.deepcopy(tx_hgvs_not_delins)
-            # Check for +ve base and adjust
-            if (re.search('\+', str(rn_tx_hgvs_not_delins.posedit.pos.start)) or re.search('\-',
-                                                                                           str(
-                                                                                               rn_tx_hgvs_not_delins.posedit.pos.start))) and (
-                    re.search('\+', str(rn_tx_hgvs_not_delins.posedit.pos.end)) or re.search(
-                '\-', str(rn_tx_hgvs_not_delins.posedit.pos.end))):
-                # Remove offsetting to span the gap
-                rn_tx_hgvs_not_delins.posedit.pos.start.offset = 0
-                rn_tx_hgvs_not_delins.posedit.pos.end.offset = 0
-                rn_tx_hgvs_not_delins.posedit.pos.end.base = rn_tx_hgvs_not_delins.posedit.pos.end.base + 1
-                rn_tx_hgvs_not_delins.posedit.edit.ref = ''
-                try:
-                    rn_tx_hgvs_not_delins.posedit.edit.alt = ''
-                except:
-                    pass
-            elif re.search('\+', str(rn_tx_hgvs_not_delins.posedit.pos.end)):
-                # move tx end base to next available non-offset base
-                rn_tx_hgvs_not_delins.posedit.pos.end.base = tx_hgvs_not_delins.posedit.pos.end.base + 1
-                rn_tx_hgvs_not_delins.posedit.pos.end.offset = 0
-                rn_tx_hgvs_not_delins.posedit.edit.ref = ''
-                if re.match('NM_', str(rn_tx_hgvs_not_delins)):
-                    test_tx_var = no_norm_evm.n_to_c(rn_tx_hgvs_not_delins)
-                else:
-                    test_tx_var = rn_tx_hgvs_not_delins
-                # re-make genomic and tx
-                hgvs_not_delins = vfo.myevm_t_to_g(test_tx_var, no_norm_evm, primary_assembly, hn)
-
-                rn_tx_hgvs_not_delins = no_norm_evm.g_to_n(hgvs_not_delins,
-                                                           str(saved_hgvs_coding.ac))
-            elif re.search('\+', str(rn_tx_hgvs_not_delins.posedit.pos.start)):
-                # move tx start base to previous available non-offset base
-                rn_tx_hgvs_not_delins.posedit.pos.start.offset = 0
-                rn_tx_hgvs_not_delins.posedit.edit.ref = ''
-                if re.match('NM_', str(rn_tx_hgvs_not_delins)):
-                    test_tx_var = no_norm_evm.n_to_c(rn_tx_hgvs_not_delins)
-                else:
-                    test_tx_var = rn_tx_hgvs_not_delins
-                # re-make genomic and tx
-                hgvs_not_delins = vfo.myevm_t_to_g(test_tx_var, no_norm_evm, primary_assembly, hn)
-                rn_tx_hgvs_not_delins = no_norm_evm.g_to_n(hgvs_not_delins,
-                                                           str(saved_hgvs_coding.ac))
-                rn_tx_hgvs_not_delins.posedit.pos.start.offset = 0
-
-            # Check for -ve base and adjust
-            elif re.search('\-', str(rn_tx_hgvs_not_delins.posedit.pos.end)) and re.search('\-',
-                                                                                           str(
-                                                                                               rn_tx_hgvs_not_delins.posedit.pos.start)):
-                # Remove offsetting to span the gap
-                rn_tx_hgvs_not_delins.posedit.pos.start.offset = 0
-                rn_tx_hgvs_not_delins.posedit.pos.end.offset = 0
-                rn_tx_hgvs_not_delins.posedit.pos.end.base = rn_tx_hgvs_not_delins.posedit.pos.end.base + 1
-                rn_tx_hgvs_not_delins.posedit.edit.ref = ''
-                try:
-                    rn_tx_hgvs_not_delins.posedit.edit.alt = ''
-                except:
-                    pass
-            elif re.search('\-', str(rn_tx_hgvs_not_delins.posedit.pos.end)):
-                # move tx end base back to next available non-offset base
-                rn_tx_hgvs_not_delins.posedit.pos.end.offset = 0
-                # Delete the ref
-                rn_tx_hgvs_not_delins.posedit.edit.ref = ''
-                # Add the additional base to the ALT
-                start = rn_tx_hgvs_not_delins.posedit.pos.end.base - 1
-                end = rn_tx_hgvs_not_delins.posedit.pos.end.base
-                ref_bases = sf.fetch_seq(str(tx_hgvs_not_delins.ac), start, end)
-                rn_tx_hgvs_not_delins.posedit.edit.alt = rn_tx_hgvs_not_delins.posedit.edit.alt + ref_bases
-                if re.match('NM_', str(rn_tx_hgvs_not_delins)):
-                    test_tx_var = no_norm_evm.n_to_c(rn_tx_hgvs_not_delins)
-                else:
-                    test_tx_var = rn_tx_hgvs_not_delins
-                # re-make genomic and tx
-                hgvs_not_delins = vfo.myevm_t_to_g(test_tx_var, no_norm_evm, primary_assembly, hn)
-                rn_tx_hgvs_not_delins = no_norm_evm.g_to_n(hgvs_not_delins,
-                                                           str(saved_hgvs_coding.ac))
-            elif re.search('\-', str(rn_tx_hgvs_not_delins.posedit.pos.start)):
-                # move tx start base to previous available non-offset base
-                rn_tx_hgvs_not_delins.posedit.pos.start.offset = 0
-                rn_tx_hgvs_not_delins.posedit.pos.start.base = rn_tx_hgvs_not_delins.posedit.pos.start.base - 1
-                rn_tx_hgvs_not_delins.posedit.edit.ref = ''
-                if re.match('NM_', str(rn_tx_hgvs_not_delins)):
-                    test_tx_var = no_norm_evm.n_to_c(rn_tx_hgvs_not_delins)
-                else:
-                    test_tx_var = rn_tx_hgvs_not_delins
-                # re-make genomic and tx
-                hgvs_not_delins = vfo.myevm_t_to_g(test_tx_var, no_norm_evm, primary_assembly, hn)
-                rn_tx_hgvs_not_delins = no_norm_evm.g_to_n(hgvs_not_delins,
-                                                           str(saved_hgvs_coding.ac))
-                rn_tx_hgvs_not_delins.posedit.pos.start.offset = 0
-            else:
-                pass
-
-            # Logic
-            if len(hgvs_not_delins.posedit.edit.ref) < len(
-                    rn_tx_hgvs_not_delins.posedit.edit.ref):
-                gap_length = len(rn_tx_hgvs_not_delins.posedit.edit.ref) - len(
-                    hgvs_not_delins.posedit.edit.ref)
-                disparity_deletion_in = ['chromosome', gap_length]
-            elif len(hgvs_not_delins.posedit.edit.ref) > len(
-                    rn_tx_hgvs_not_delins.posedit.edit.ref):
-                gap_length = len(hgvs_not_delins.posedit.edit.ref) - len(
-                    rn_tx_hgvs_not_delins.posedit.edit.ref)
-                disparity_deletion_in = ['transcript', gap_length]
-            else:
-                hgvs_stash_t = vm.g_to_t(stash_hgvs_not_delins, saved_hgvs_coding.ac)
-                if len(stash_hgvs_not_delins.posedit.edit.ref) > len(
-                        hgvs_stash_t.posedit.edit.ref):
-                    try:
-                        hn.normalize(hgvs_stash_t)
-                    except:
-                        pass
-                    else:
-                        gap_length = len(stash_hgvs_not_delins.posedit.edit.ref) - len(
-                            hgvs_stash_t.posedit.edit.ref)
-                        disparity_deletion_in = ['transcript', gap_length]
-                        try:
-                            tx_hgvs_not_delins = vm.c_to_n(hgvs_stash_t)
-                        except:
-                            tx_hgvs_not_delins = hgvs_stash_t
-                        hgvs_not_delins = stash_hgvs_not_delins
-                elif hgvs_stash_t.posedit.pos.start.offset != 0 or hgvs_stash_t.posedit.pos.end.offset != 0:
-                    disparity_deletion_in = ['transcript', 'Requires Analysis']
-                    try:
-                        tx_hgvs_not_delins = vm.c_to_n(hgvs_stash_t)
-                    except:
-                        tx_hgvs_not_delins = hgvs_stash_t
-                    hgvs_not_delins = stash_hgvs_not_delins
-                    hgvs_genomic_5pr = stash_hgvs_not_delins
-                else:
-                    pass
-
-        # Final sanity checks
-        try:
-            vm.g_to_t(hgvs_not_delins, tx_hgvs_not_delins.ac)
-        except Exception as e:
-            if str(e) == 'start or end or both are beyond the bounds of transcript record':
-                hgvs_not_delins = saved_hgvs_coding
-                disparity_deletion_in = ['false', 'false']
-        try:
-            hn.normalize(tx_hgvs_not_delins)
-        except vvhgvs.exceptions.HGVSUnsupportedOperationError as e:
-            error = str(e)
-            if re.match('Normalization of intronic variants is not supported',
-                        error) or re.match(
-                'Unsupported normalization of variants spanning the exon-intron boundary',
-                error):
-                if re.match(
-                        'Unsupported normalization of variants spanning the exon-intron boundary',
-                        error):
-                    hgvs_not_delins = saved_hgvs_coding
-                    disparity_deletion_in = ['false', 'false']
-                elif re.match('Normalization of intronic variants is not supported', error):
-                    # We know that this cannot be because of an intronic variant, so must be aligned to tx gap
-                    disparity_deletion_in = ['transcript', 'Requires Analysis']
-
-        # Pre-processing of tx_hgvs_not_delins
-        try:
-            if tx_hgvs_not_delins.posedit.edit.alt is None:
-                tx_hgvs_not_delins.posedit.edit.alt = ''
-        except Exception as e:
-            if str(e) == "'Dup' object has no attribute 'alt'":
-                tx_hgvs_not_delins_delins_from_dup = tx_hgvs_not_delins.ac + ':' + tx_hgvs_not_delins.type + '.' + str(
-                    tx_hgvs_not_delins.posedit.pos.start) + '_' + str(
-                    tx_hgvs_not_delins.posedit.pos.end) + 'del' + tx_hgvs_not_delins.posedit.edit.ref + 'ins' + tx_hgvs_not_delins.posedit.edit.ref + tx_hgvs_not_delins.posedit.edit.ref
-                tx_hgvs_not_delins = hp.parse_hgvs_variant(tx_hgvs_not_delins_delins_from_dup)
-
-        # GAP IN THE TRANSCRIPT DISPARITY DETECTED
-        if disparity_deletion_in[0] == 'transcript':
-            if disparity_deletion_in[1] == 'Requires Analysis':
-                analyse_gap = copy.deepcopy(tx_hgvs_not_delins)
-                try:
-                    analyse_gap = vm.n_to_c(analyse_gap)
-                except vvhgvs.exceptions.HGVSError:
-                    pass
-                analyse_gap.posedit.pos.start.offset = 0
-                analyse_gap.posedit.pos.end.offset = 0
-                try:
-                    analyse_gap.posedit.edit.ref = ''
-                except AttributeError:
-                    pass
-                try:
-                    analyse_gap.posedit.edit.alt = ''
-                except AttributeError:
-                    pass
-                my_g_gap_v = vm.t_to_g(analyse_gap, hgvs_genomic_5pr.ac)
-                g_gap = my_g_gap_v.posedit.pos.end.base - my_g_gap_v.posedit.pos.start.base + 1
-                my_t_gap_v = vm.g_to_t(my_g_gap_v, analyse_gap.ac)
-                t_gap = my_t_gap_v.posedit.pos.end.base - my_t_gap_v.posedit.pos.start.base
-                disparity_deletion_in[1] = str(g_gap - t_gap - 1)
-
-            gap_position = ''
-            gapped_alignment_warning = 'The displayed variants may be artefacts of aligning ' + tx_hgvs_not_delins.ac + ' with genome build ' + primary_assembly
-
-            # ANY VARIANT WHOLLY WITHIN THE GAP
-            if (re.search('\+', str(tx_hgvs_not_delins.posedit.pos.start)) or re.search('\-',
-                                                                                        str(
-                                                                                            tx_hgvs_not_delins.posedit.pos.start))) and (
-                    re.search('\+', str(tx_hgvs_not_delins.posedit.pos.end)) or re.search('\-',
-                                                                                          str(
-                                                                                              tx_hgvs_not_delins.posedit.pos.end))):
-                gapped_transcripts = gapped_transcripts + ' ' + str(tx_hgvs_not_delins.ac)
-                # Copy the current variant
-                tx_gap_fill_variant = copy.deepcopy(tx_hgvs_not_delins)
-                try:
-                    if tx_gap_fill_variant.posedit.edit.alt is None:
-                        tx_gap_fill_variant.posedit.edit.alt = ''
-                except Exception as e:
-                    if str(e) == "'Dup' object has no attribute 'alt'":
-                        tx_gap_fill_variant_delins_from_dup = tx_gap_fill_variant.ac + ':' + tx_gap_fill_variant.type + '.' + str(
-                            tx_gap_fill_variant.posedit.pos.start) + '_' + str(
-                            tx_gap_fill_variant.posedit.pos.end) + 'del' + tx_gap_fill_variant.posedit.edit.ref + 'ins' + tx_gap_fill_variant.posedit.edit.ref + tx_gap_fill_variant.posedit.edit.ref
-                        tx_gap_fill_variant = hp.parse_hgvs_variant(
-                            tx_gap_fill_variant_delins_from_dup)
-
-                # Identify which half of the NOT-intron the start position of the variant is in
-                if re.search('\-', str(tx_gap_fill_variant.posedit.pos.start)):
-                    tx_gap_fill_variant.posedit.pos.start.base = tx_gap_fill_variant.posedit.pos.start.base - 1
-                    tx_gap_fill_variant.posedit.pos.start.offset = int('0')  # int('+1')
-                    tx_gap_fill_variant.posedit.pos.end.offset = int('0')  # int('-1')
-                    tx_gap_fill_variant.posedit.edit.alt = ''
-                    tx_gap_fill_variant.posedit.edit.ref = ''
-                elif re.search('\+', str(tx_gap_fill_variant.posedit.pos.start)):
-                    tx_gap_fill_variant.posedit.pos.start.offset = int('0')  # int('+1')
-                    tx_gap_fill_variant.posedit.pos.end.base = tx_gap_fill_variant.posedit.pos.end.base + 1
-                    tx_gap_fill_variant.posedit.pos.end.offset = int('0')  # int('-1')
-                    tx_gap_fill_variant.posedit.edit.alt = ''
-                    tx_gap_fill_variant.posedit.edit.ref = ''
-
-                try:
-                    tx_gap_fill_variant = vm.n_to_c(tx_gap_fill_variant)
-                except:
-                    pass
-                genomic_gap_fill_variant = vm.t_to_g(tx_gap_fill_variant,
-                                                     reverse_normalized_hgvs_genomic.ac)
-                genomic_gap_fill_variant.posedit.edit.alt = genomic_gap_fill_variant.posedit.edit.ref
-
-                try:
-                    c_tx_hgvs_not_delins = vm.n_to_c(tx_hgvs_not_delins)
-                except Exception:
-                    c_tx_hgvs_not_delins = copy.copy(tx_hgvs_not_delins)
-                genomic_gap_fill_variant_alt = vm.t_to_g(c_tx_hgvs_not_delins,
-                                                         hgvs_genomic_5pr.ac)
-
-                # Ensure an ALT exists
-                try:
-                    if genomic_gap_fill_variant_alt.posedit.edit.alt is None:
-                        genomic_gap_fill_variant_alt.posedit.edit.alt = 'X'
-                except Exception as e:
-                    if str(e) == "'Dup' object has no attribute 'alt'":
-                        genomic_gap_fill_variant_delins_from_dup = genomic_gap_fill_variant.ac + ':' + genomic_gap_fill_variant.type + '.' + str(
-                            genomic_gap_fill_variant.posedit.pos.start.base) + '_' + str(
-                            genomic_gap_fill_variant.posedit.pos.end.base) + 'del' + genomic_gap_fill_variant.posedit.edit.ref + 'ins' + genomic_gap_fill_variant.posedit.edit.ref + genomic_gap_fill_variant.posedit.edit.ref
-                        genomic_gap_fill_variant = hp.parse_hgvs_variant(
-                            genomic_gap_fill_variant_delins_from_dup)
-                        genomic_gap_fill_variant_alt_delins_from_dup = genomic_gap_fill_variant_alt.ac + ':' + genomic_gap_fill_variant_alt.type + '.' + str(
-                            genomic_gap_fill_variant_alt.posedit.pos.start.base) + '_' + str(
-                            genomic_gap_fill_variant_alt.posedit.pos.end.base) + 'del' + genomic_gap_fill_variant_alt.posedit.edit.ref + 'ins' + genomic_gap_fill_variant_alt.posedit.edit.ref + genomic_gap_fill_variant_alt.posedit.edit.ref
-                        genomic_gap_fill_variant_alt = hp.parse_hgvs_variant(
-                            genomic_gap_fill_variant_alt_delins_from_dup)
-
-                # Correct insertion alts
-                if genomic_gap_fill_variant_alt.posedit.edit.type == 'ins':
-                    append_ref = sf.fetch_seq(genomic_gap_fill_variant_alt.ac,
-                                              genomic_gap_fill_variant_alt.posedit.pos.start.base - 1,
-                                              genomic_gap_fill_variant_alt.posedit.pos.end.base)
-                    genomic_gap_fill_variant_alt.posedit.edit.alt = append_ref[
-                                                                        0] + genomic_gap_fill_variant_alt.posedit.edit.alt + \
-                                                                    append_ref[1]
-
-                # Split the reference and replacing alt sequence into a dictionary
-                reference_bases = list(genomic_gap_fill_variant.posedit.edit.ref)
-                if genomic_gap_fill_variant_alt.posedit.edit.alt is not None:
-                    alternate_bases = list(genomic_gap_fill_variant_alt.posedit.edit.alt)
-                else:
-                    # Deletions with no ins
-                    pre_alternate_bases = list(genomic_gap_fill_variant_alt.posedit.edit.ref)
-                    alternate_bases = []
-                    for base in pre_alternate_bases:
-                        alternate_bases.append('X')
-
-                # Create the dictionaries
-                ref_start = genomic_gap_fill_variant.posedit.pos.start.base
-                alt_start = genomic_gap_fill_variant_alt.posedit.pos.start.base
-                ref_base_dict = {}
-                for base in reference_bases:
-                    ref_base_dict[ref_start] = str(base)
-                    ref_start = ref_start + 1
-
-                alt_base_dict = {}
-
-                # NEED TO SEARCH FOR RANGE = and replace with interval_range
-                # Need to search for int and replace with integer
-
-                # Note, all variants will be forced into the format delete insert
-                # Deleted bases in the ALT will be substituted for X
-                for integer in range(genomic_gap_fill_variant_alt.posedit.pos.start.base,
-                                     genomic_gap_fill_variant_alt.posedit.pos.end.base + 1, 1):
-                    if integer == alt_start:
-                        alt_base_dict[integer] = str(''.join(alternate_bases))
-                    else:
-                        alt_base_dict[integer] = 'X'
-
-                # Generate the alt sequence
-                alternate_sequence_bases = []
-                for integer in range(genomic_gap_fill_variant.posedit.pos.start.base,
-                                     genomic_gap_fill_variant.posedit.pos.end.base + 1, 1):
-                    if integer in alt_base_dict.keys():
-                        alternate_sequence_bases.append(alt_base_dict[integer])
-                    else:
-                        alternate_sequence_bases.append(ref_base_dict[integer])
-                alternate_sequence = ''.join(alternate_sequence_bases)
-                alternate_sequence = alternate_sequence.replace('X', '')
-
-                # Add the new alt to the gap fill variant and generate transcript variant
-                genomic_gap_fill_variant.posedit.edit.alt = alternate_sequence
-                hgvs_refreshed_variant = vm.g_to_t(genomic_gap_fill_variant,
-                                                   tx_gap_fill_variant.ac)
-
-                # Set warning
-                gap_size = str(len(genomic_gap_fill_variant.posedit.edit.ref) - 2)
-                disparity_deletion_in[1] = [gap_size]
-                auto_info = str(stored_hgvs_not_delins.ac) + ':g.' + str(
-                    stored_hgvs_not_delins.posedit.pos.start.base) + ' is one of ' + gap_size + ' genomic base(s) that fail to align to transcript ' + str(
-                    tx_hgvs_not_delins.ac)
-                non_valid_caution = 'true'
-
-                # Alignment position
-                for_location_c = copy.deepcopy(hgvs_refreshed_variant)
-                if re.match('NM_', str(for_location_c)):
-                    for_location_c = no_norm_evm.n_to_c(tx_hgvs_not_delins)
-                if re.match('\-', str(for_location_c.posedit.pos.start.offset)):
-                    gps = for_location_c.posedit.pos.start.base - 1
-                    gpe = for_location_c.posedit.pos.start.base
-                else:
-                    gps = for_location_c.posedit.pos.start.base
-                    gpe = for_location_c.posedit.pos.start.base + 1
-                gap_position = ' between positions c.' + str(gps) + '_' + str(gpe)
-                # auto_info = '%s' % (gap_position)
-            else:
-                if tx_hgvs_not_delins.posedit.pos.start.offset == 0 and tx_hgvs_not_delins.posedit.pos.end.offset == 0:
-                    # In this instance, we have identified a transcript gap but the n. version of
-                    # the transcript variant but do not have a position which actually hits the gap,
-                    # so the variant likely spans the gap, and is not picked up by an offset.
-                    try:
-                        c1 = vm.n_to_c(tx_hgvs_not_delins)
-                    except:
-                        c1 = tx_hgvs_not_delins
-                    g1 = nr_vm.t_to_g(c1, hgvs_genomic.ac)
-                    g3 = nr_vm.t_to_g(c1, hgvs_genomic.ac)
-                    g2 = vm.t_to_g(c1, hgvs_genomic.ac)
-                    ng2 = hn.normalize(g2)
-                    g3.posedit.pos.end.base = g3.posedit.pos.start.base + (
-                                len(g3.posedit.edit.ref) - 1)
-                    try:
-                        c2 = vm.g_to_t(g3, c1.ac)
-                        if c2.posedit.pos.start.offset == 0 and c2.posedit.pos.end.offset == 0:
-                            pass
-                        else:
-                            tx_hgvs_not_delins = c2
-                            try:
-                                tx_hgvs_not_delins = vm.c_to_n(tx_hgvs_not_delins)
-                            except vvhgvs.exceptions.HGVSError:
-                                pass
-                    except vvhgvs.exceptions.HGVSInvalidVariantError:
-                        pass
-
-                if re.search('\+', str(tx_hgvs_not_delins.posedit.pos.start)) and not re.search(
-                        '\+', str(tx_hgvs_not_delins.posedit.pos.end)):
-                    auto_info = str(stored_hgvs_not_delins.ac) + ':g.' + str(
-                        stored_hgvs_not_delins.posedit.pos.start.base) + ' is one of ' + str(
-                        disparity_deletion_in[
-                            1]) + ' genomic base(s) that fail to align to transcript ' + str(
-                        tx_hgvs_not_delins.ac)
-                    non_valid_caution = 'true'
-                    try:
-                        c2 = vm.n_to_c(tx_hgvs_not_delins)
-                    except:
-                        c2 = tx_hgvs_not_delins
-                    c1 = copy.deepcopy(c2)
-                    c1.posedit.pos.start.base = c2.posedit.pos.start.base - 1
-                    c1.posedit.pos.start.offset = 0
-                    c1.posedit.pos.end = c2.posedit.pos.start
-                    c1.posedit.edit.ref = ''
-                    c1.posedit.edit.alt = ''
-                    if orientation != -1:
-                        g1 = vm.t_to_g(c1, hgvs_genomic.ac)
-                        g2 = vm.t_to_g(c2, hgvs_genomic.ac)
-                        g1.posedit.edit.alt = g1.posedit.edit.ref
-                    else:
-                        g1 = vm.t_to_g(c2, hgvs_genomic.ac)
-                        g2 = vm.t_to_g(c1, hgvs_genomic.ac)
-                        g2.posedit.edit.alt = g2.posedit.edit.ref
-                    reference = g1.posedit.edit.ref + g2.posedit.edit.ref[1:]
-                    alternate = g1.posedit.edit.alt + g2.posedit.edit.alt[1:]
-                    g3 = copy.deepcopy(g1)
-                    g3.posedit.pos.end.base = g2.posedit.pos.end.base
-                    g3.posedit.edit.ref = reference
-                    g3.posedit.edit.alt = alternate
-                    c3 = vm.g_to_t(g3, c1.ac)
-                    hgvs_refreshed_variant = c3
-                    # Alignment position
-                    for_location_c = copy.deepcopy(hgvs_refreshed_variant)
-                    if re.match('NM_', str(for_location_c)):
-                        for_location_c = no_norm_evm.n_to_c(tx_hgvs_not_delins)
-                        gps = for_location_c.posedit.pos.start.base
-                        gpe = for_location_c.posedit.pos.start.base + 1
-                    gap_position = ' between positions c.' + str(gps) + '_' + str(gpe)
-                    # Warn update
-                    # auto_info = '%s' % (gap_position)
-                elif re.search('\+', str(tx_hgvs_not_delins.posedit.pos.end)) and not re.search(
-                        '\+', str(tx_hgvs_not_delins.posedit.pos.start)):
-                    auto_info = 'Genome position ' + str(
-                        stored_hgvs_not_delins.ac) + ':g.' + str(
-                        stored_hgvs_not_delins.posedit.pos.end.base) + ' aligns within a gap in transcript ' + str(
-                        tx_hgvs_not_delins.ac)
-                    gapped_transcripts = gapped_transcripts + ' ' + str(tx_hgvs_not_delins.ac)
-                    non_valid_caution = 'true'
-                    try:
-                        c1 = vm.n_to_c(tx_hgvs_not_delins)
-                    except:
-                        c1 = tx_hgvs_not_delins
-                    c2 = copy.deepcopy(c1)
-                    c2.posedit.pos.start = c1.posedit.pos.end
-                    c2.posedit.pos.end.base = c1.posedit.pos.end.base + 1
-                    c2.posedit.pos.end.offset = 0
-                    c2.posedit.edit.ref = ''
-                    c2.posedit.edit.alt = ''
-                    if orientation != -1:
-                        g1 = vm.t_to_g(c1, hgvs_genomic.ac)
-                        g2 = vm.t_to_g(c2, hgvs_genomic.ac)
-                        g2.posedit.edit.alt = g2.posedit.edit.ref
-                    else:
-                        g1 = vm.t_to_g(c2, hgvs_genomic.ac)
-                        g2 = vm.t_to_g(c1, hgvs_genomic.ac)
-                        g1.posedit.edit.alt = g1.posedit.edit.ref
-                    reference = g1.posedit.edit.ref + g2.posedit.edit.ref[1:]
-                    alternate = g1.posedit.edit.alt + g2.posedit.edit.alt[1:]
-                    g3 = copy.deepcopy(g1)
-                    g3.posedit.pos.end.base = g2.posedit.pos.end.base
-                    g3.posedit.edit.ref = reference
-                    g3.posedit.edit.alt = alternate
-                    c3 = vm.g_to_t(g3, c1.ac)
-                    hgvs_refreshed_variant = c3
-                    # Alignment position
-                    for_location_c = copy.deepcopy(hgvs_refreshed_variant)
-                    if re.match('NM_', str(for_location_c)):
-                        for_location_c = no_norm_evm.n_to_c(tx_hgvs_not_delins)
-                    gps = for_location_c.posedit.pos.end.base
-                    gpe = for_location_c.posedit.pos.end.base + 1
-                    gap_position = ' between positions c.' + str(gps) + '_' + str(gpe)
-                    # Warn update
-                    # auto_info = '%s' % (gap_position)
-                elif re.search('\-',
-                               str(tx_hgvs_not_delins.posedit.pos.start)) and not re.search(
-                    '\-', str(tx_hgvs_not_delins.posedit.pos.end)):
-                    auto_info = str(stored_hgvs_not_delins.ac) + ':g.' + str(
-                        stored_hgvs_not_delins.posedit.pos.start.base) + ' is one of ' + str(
-                        disparity_deletion_in[
-                            1]) + ' genomic base(s) that fail to align to transcript ' + str(
-                        tx_hgvs_not_delins.ac)
-                    non_valid_caution = 'true'
-                    try:
-                        c2 = vm.n_to_c(tx_hgvs_not_delins)
-                    except:
-                        c2 = tx_hgvs_not_delins
-                    c1 = copy.deepcopy(c2)
-                    c1.posedit.pos.start.base = c2.posedit.pos.start.base - 1
-                    c1.posedit.pos.start.offset = 0
-                    c1.posedit.pos.end = c2.posedit.pos.start
-                    c1.posedit.edit.ref = ''
-                    c1.posedit.edit.alt = ''
-                    if orientation != -1:
-                        g1 = vm.t_to_g(c1, hgvs_genomic.ac)
-                        g2 = vm.t_to_g(c2, hgvs_genomic.ac)
-                        g1.posedit.edit.alt = g1.posedit.edit.ref
-                    else:
-                        g1 = vm.t_to_g(c2, hgvs_genomic.ac)
-                        g2 = vm.t_to_g(c1, hgvs_genomic.ac)
-                        g2.posedit.edit.alt = g2.posedit.edit.ref
-                    reference = g1.posedit.edit.ref + g2.posedit.edit.ref[1:]
-                    alternate = g1.posedit.edit.alt + g2.posedit.edit.alt[1:]
-                    g3 = copy.deepcopy(g1)
-                    g3.posedit.pos.end.base = g2.posedit.pos.end.base
-                    g3.posedit.edit.ref = reference
-                    g3.posedit.edit.alt = alternate
-                    c3 = vm.g_to_t(g3, c1.ac)
-                    hgvs_refreshed_variant = c3
-                    # Alignment position
-                    for_location_c = copy.deepcopy(hgvs_refreshed_variant)
-                    if re.match('NM_', str(for_location_c)):
-                        for_location_c = no_norm_evm.n_to_c(tx_hgvs_not_delins)
-                    gps = for_location_c.posedit.pos.start.base - 1
-                    gpe = for_location_c.posedit.pos.start.base
-                    gap_position = ' between positions c.' + str(gps) + '_' + str(gpe)
-                    # Warn update
-                    # auto_info = '%s' % (gap_position)
-                elif re.search('\-', str(tx_hgvs_not_delins.posedit.pos.end)) and not re.search(
-                        '\-', str(tx_hgvs_not_delins.posedit.pos.start)):
-                    auto_info = 'Genome position ' + str(
-                        stored_hgvs_not_delins.ac) + ':g.' + str(
-                        stored_hgvs_not_delins.posedit.pos.end.base) + ' aligns within a gap in transcript ' + str(
-                        tx_hgvs_not_delins.ac)
-                    gapped_transcripts = gapped_transcripts + ' ' + str(tx_hgvs_not_delins.ac)
-                    non_valid_caution = 'true'
-                    try:
-                        c1 = vm.n_to_c(tx_hgvs_not_delins)
-                    except:
-                        c1 = tx_hgvs_not_delins
-                    c2 = copy.deepcopy(c1)
-                    c2.posedit.pos.start = c1.posedit.pos.end
-                    c2.posedit.pos.end.base = c1.posedit.pos.end.base
-                    c2.posedit.pos.end.offset = 0
-                    c2.posedit.edit.ref = ''
-                    c2.posedit.edit.alt = ''
-                    g2 = vm.t_to_g(c2, hgvs_genomic.ac)
-                    c2 = vm.g_to_t(g2, c2.ac)
-                    reference = c1.posedit.edit.ref + c2.posedit.edit.ref[1:]
-                    alternate = c1.posedit.edit.alt + c2.posedit.edit.ref[1:]
-                    c3 = copy.deepcopy(c1)
-                    c3.posedit.pos.end = c2.posedit.pos.end
-                    c3.posedit.edit.ref = ''  # reference
-                    c3.posedit.edit.alt = alternate
-                    hgvs_refreshed_variant = c3
-                    # Alignment position
-                    for_location_c = copy.deepcopy(hgvs_refreshed_variant)
-                    if re.match('NM_', str(for_location_c)):
-                        for_location_c = no_norm_evm.n_to_c(tx_hgvs_not_delins)
-                    gps = for_location_c.posedit.pos.end.base - 1
-                    gpe = for_location_c.posedit.pos.end.base
-                    gap_position = ' between positions c.' + str(gps) + '_' + str(gpe)
-                    # Warn update
-                    # auto_info = '%s' % (gap_position)
-                else:
-                    auto_info = str(stored_hgvs_not_delins.ac) + ':g.' + str(
-                        stored_hgvs_not_delins.posedit.pos) + ' contains ' + str(
-                        disparity_deletion_in[
-                            1]) + ' genomic base(s) that fail to align to transcript ' + str(
-                        tx_hgvs_not_delins.ac)
-                    hgvs_refreshed_variant = tx_hgvs_not_delins
-                    gapped_transcripts = gapped_transcripts + ' ' + str(tx_hgvs_not_delins.ac)
-
-        # GAP IN THE CHROMOSOME
-        elif disparity_deletion_in[0] == 'chromosome':
-            # Set warning variables
-            gap_position = ''
-            gapped_alignment_warning = 'The displayed variants may be artefacts of aligning ' + tx_hgvs_not_delins.ac + ' with genome build ' + primary_assembly
-            hgvs_refreshed_variant = tx_hgvs_not_delins
-            # Warn
-            auto_info = str(hgvs_refreshed_variant.ac) + ':c.' + str(
-                hgvs_refreshed_variant.posedit.pos) + ' contains ' + str(disparity_deletion_in[
-                                                                             1]) + ' transcript base(s) that fail to align to chromosome ' + str(
-                hgvs_genomic.ac)
-            gapped_transcripts = gapped_transcripts + str(hgvs_refreshed_variant.ac) + ' '
-        else:
-            # Try the push
-            hgvs_stash = copy.deepcopy(stash_hgvs_not_delins)
-            stash_ac = hgvs_stash.ac
-            # Make a hard left and hard right not delins g.
-            stash_dict_right = va_H2V.hard_right_hgvs2vcf(hgvs_stash, primary_assembly, hn, sf)
-            stash_pos_right = int(stash_dict_right['pos'])
-            stash_ref_right = stash_dict_right['ref']
-            stash_alt_right = stash_dict_right['alt']
-            stash_end_right = str(stash_pos_right + len(stash_ref_right) - 1)
-            stash_hgvs_not_delins_right = hp.parse_hgvs_variant(stash_ac + ':' + hgvs_stash.type + '.' + str(
-                    stash_pos_right) + '_' + stash_end_right + 'del' + stash_ref_right + 'ins' + stash_alt_right)
-            stash_dict_left = va_H2V.hard_left_hgvs2vcf(hgvs_stash, primary_assembly, reverse_normalizer, sf)
-            stash_pos_left = int(stash_dict_left['pos'])
-            stash_ref_left = stash_dict_left['ref']
-            stash_alt_left = stash_dict_left['alt']
-            stash_end_left = str(stash_pos_left + len(stash_ref_left) - 1)
-            stash_hgvs_not_delins_left = hp.parse_hgvs_variant(stash_ac + ':' + hgvs_stash.type + '.' + str(
-                    stash_pos_left) + '_' + stash_end_left + 'del' + stash_ref_left + 'ins' + stash_alt_left)
-            # Map in-situ to the transcript left and right
-            try:
-                tx_hard_right = vm.g_to_t(stash_hgvs_not_delins_right, saved_hgvs_coding.ac)
-            except Exception as e:
-                tx_hard_right = saved_hgvs_coding
-            else:
-                normalize_stash_right = hn.normalize(stash_hgvs_not_delins_right)
-                if str(normalize_stash_right.posedit) == str(stash_hgvs_not_delins.posedit):
-                    tx_hard_right = saved_hgvs_coding
-            try:
-                tx_hard_left = vm.g_to_t(stash_hgvs_not_delins_left, saved_hgvs_coding.ac)
-            except Exception as e:
-                tx_hard_left = saved_hgvs_coding
-            else:
-                normalize_stash_left = hn.normalize(stash_hgvs_not_delins_left)
-                if str(normalize_stash_left.posedit) == str(stash_hgvs_not_delins.posedit):
-                    tx_hard_left = saved_hgvs_coding
-            # The Logic - Currently limited to genome gaps
-            if len(stash_hgvs_not_delins_right.posedit.edit.ref) < len(
-                    tx_hard_right.posedit.edit.ref):
-                tx_hard_right = hn.normalize(tx_hard_right)
-                gap_position = ''
-                gapped_alignment_warning = 'The displayed variants may be artefacts of aligning ' + tx_hgvs_not_delins.ac + ' with genome build ' + primary_assembly
-                hgvs_refreshed_variant = tx_hard_right
-                gapped_transcripts = gapped_transcripts + str(tx_hard_right.ac) + ' '
-            elif len(stash_hgvs_not_delins_left.posedit.edit.ref) < len(
-                    tx_hard_left.posedit.edit.ref):
-                tx_hard_left = hn.normalize(tx_hard_left)
-                gap_position = ''
-                gapped_alignment_warning = 'The displayed variants may be artefacts of aligning ' + tx_hgvs_not_delins.ac + ' with genome build ' + primary_assembly
-                hgvs_refreshed_variant = tx_hard_left
-                gapped_transcripts = gapped_transcripts + str(tx_hard_left.ac) + ' '
-            else:
-                # Keep the same by re-setting rel_var
-                hgvs_refreshed_variant = saved_hgvs_coding
-
-        # Edit the output
-        if re.match('NM_', str(hgvs_refreshed_variant.ac)) and not re.search('c', str(
-                hgvs_refreshed_variant.type)):
-            hgvs_refreshed_variant = evm.n_to_c(hgvs_refreshed_variant)
-        else:
-            pass
-        
-        # Set pos_lock
-        pos_lock = True
-        
-        try:
-            hgvs_refreshed_variant = hn.normalize(hgvs_refreshed_variant)
-            if hgvs_refreshed_variant.posedit.edit.type == 'delins' and \
-                    hgvs_refreshed_variant.posedit.edit.ref[-1] == \
-                    hgvs_refreshed_variant.posedit.edit.alt[-1]:
-                hgvs_refreshed_variant.posedit.edit.ref = hgvs_refreshed_variant.posedit.edit.ref[
-                                                          0:-1]
-                hgvs_refreshed_variant.posedit.edit.alt = hgvs_refreshed_variant.posedit.edit.alt[
-                                                          0:-1]
-                hgvs_refreshed_variant.posedit.pos.end.base = hgvs_refreshed_variant.posedit.pos.end.base - 1
-                hgvs_refreshed_variant = hn.normalize(hgvs_refreshed_variant)
-            elif hgvs_refreshed_variant.posedit.edit.type == 'delins' and \
-                    hgvs_refreshed_variant.posedit.edit.ref[0] == \
-                    hgvs_refreshed_variant.posedit.edit.alt[0]:
-                hgvs_refreshed_variant.posedit.edit.ref = hgvs_refreshed_variant.posedit.edit.ref[
-                                                          1:]
-                hgvs_refreshed_variant.posedit.edit.alt = hgvs_refreshed_variant.posedit.edit.alt[
-                                                          1:]
-                hgvs_refreshed_variant.posedit.pos.start.base = hgvs_refreshed_variant.posedit.pos.start.base + 1
-                hgvs_refreshed_variant = hn.normalize(hgvs_refreshed_variant)
-                
-        except Exception as e:
-            error = str(e)
-            # Ensure the final variant is not intronic nor does it cross exon boundaries
-            if re.match('Normalization of intronic variants is not supported',
-                        error) or re.match(
-                'Unsupported normalization of variants spanning the exon-intron boundary',
-                error):
-                hgvs_refreshed_variant = saved_hgvs_coding
-                corrective_action_taken = None
-                gapped_alignment_warning = None
-                auto_info = None
-                pos_lock = False
-            else:
-                pass
-
-    # Otherwise these variants need to be set
-    else:
-        corrective_action_taken = None
-        gapped_alignment_warning = None
-        auto_info = None
-        pos_lock = False
-        hgvs_refreshed_variant = saved_hgvs_coding
-
-    # Warn the user that the g. description is not valid
-    if gapped_alignment_warning is not None:
-        if disparity_deletion_in[0] == 'transcript':
-            corrective_action_taken = 'Automap has deleted ' + str(
-                disparity_deletion_in[1]) + ' bp from chromosomal reference sequence ' + str(
-                hgvs_genomic.ac) + ' to ensure perfect alignment with transcript reference_sequence'
-        if disparity_deletion_in[0] == 'chromosome':
-            corrective_action_taken = 'Automap has added ' + str(
-                disparity_deletion_in[1]) + ' bp to chromosomal reference sequence ' + str(
-                hgvs_genomic.ac) + ' to ensure perfect alignment with transcript reference_sequence '
-
-    # Add additional data to the front of automap
-    if auto_info is not None:
-        automap = auto_info + '\n' + automap
-    
-    # Make the return
-    gap_report = [hgvs_refreshed_variant, pos_lock, corrective_action_taken, 
-                    gapped_alignment_warning, auto_info]
-
-    return gap_report
-    
     
 # <LICENSE>
 # Copyright (C) 2019 VariantValidator Contributors

--- a/VariantFormatter/variantformatter.py
+++ b/VariantFormatter/variantformatter.py
@@ -257,8 +257,13 @@ class FormatVariant(object):
                 am_i_gapped = formatter.gap_checker(hgvs_transcript_dict['hgvs_transcript'], g_hgvs, un_norm_hgvs, self.genome_build, self.vfo)
             except Exception as e:
                 # Error detection prime location!
-                # print("Oh dear")
-                # print(e)
+                # import sys
+                # import traceback
+                # exc_type, exc_value, last_traceback = sys.exc_info()
+                # te = traceback.format_exc()
+                # tbk = [str(exc_type), str(exc_value), str(te)]
+                # er = str('\n'.join(tbk))
+                # print(er)
                 self.warning_level = 'processing_error'
                 if hgvs_transcript_dict['error'] == '':
                     hgvs_transcript_dict['error'] = None

--- a/test/test_inputs_auto.py
+++ b/test/test_inputs_auto.py
@@ -97,7 +97,7 @@ class TestVariantsAuto(object):
 		assert results['NC_000017.10:g.48279242G>T']['p_vcf'] == '17:48279242:G:T'
 		assert results['NC_000017.10:g.48279242G>T']['g_hgvs'] == 'NC_000017.10:g.48279242G>T'
 		assert results['NC_000017.10:g.48279242G>T']['genomic_variant_error'] is None
-		assert results['NC_000017.10:g.48279242G>T']['hgvs_t_and_p'] is None
+		assert results['NC_000017.10:g.48279242G>T']['hgvs_t_and_p'] == {'intergenic': {'alt_genomic_loci': None}}
 
 
 	def test_variant7(self):
@@ -177,9 +177,9 @@ class TestVariantsAuto(object):
 		assert results['1-150550916-G-A']['hgvs_t_and_p']['NM_021960.4']['p_hgvs_slc'] == 'NP_068779.1:p.(S247F)'
 		assert results['1-150550916-G-A']['hgvs_t_and_p']['NM_021960.4']['transcript_variant_error'] is None
 		assert 'NM_182763.2' in results['1-150550916-G-A']['hgvs_t_and_p'].keys()
-		assert results['1-150550916-G-A']['hgvs_t_and_p']['NM_182763.2']['t_hgvs'] is None
-		assert results['1-150550916-G-A']['hgvs_t_and_p']['NM_182763.2']['p_hgvs_tlc'] is None
-		assert results['1-150550916-G-A']['hgvs_t_and_p']['NM_182763.2']['p_hgvs_slc'] is None
+		assert results['1-150550916-G-A']['hgvs_t_and_p']['NM_182763.2']['t_hgvs'] == "NM_182763.2:c.688+403C>T"
+		assert results['1-150550916-G-A']['hgvs_t_and_p']['NM_182763.2']['p_hgvs_tlc'] == "NP_877495.1:p.?"
+		assert results['1-150550916-G-A']['hgvs_t_and_p']['NM_182763.2']['p_hgvs_slc'] == "NP_877495.1:p.?"
 		assert results['1-150550916-G-A']['hgvs_t_and_p']['NM_182763.2']['transcript_variant_error'] is None
 
 
@@ -338,9 +338,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000012.11:g.122064777C>A']['g_hgvs'] == 'NC_000012.11:g.122064777C>A'
 		assert results['NC_000012.11:g.122064777C>A']['genomic_variant_error'] is None
 		assert 'NM_032790.3' in results['NC_000012.11:g.122064777C>A']['hgvs_t_and_p'].keys()
-		assert results['NC_000012.11:g.122064777C>A']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] is None
-		assert results['NC_000012.11:g.122064777C>A']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] is None
-		assert results['NC_000012.11:g.122064777C>A']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] is None
+		assert results['NC_000012.11:g.122064777C>A']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] == "NM_032790.3:c.129_130insACACCG"
+		assert results['NC_000012.11:g.122064777C>A']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] == "NP_116179.2:p.(Pro43_Pro44insThrPro)"
+		assert results['NC_000012.11:g.122064777C>A']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] == "NP_116179.2:p.(P43_P44insTP)"
 		assert results['NC_000012.11:g.122064777C>A']['hgvs_t_and_p']['NM_032790.3']['transcript_variant_error'] is None
 
 
@@ -355,9 +355,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000012.11:g.122064776delG']['g_hgvs'] == 'NC_000012.11:g.122064776del'
 		assert results['NC_000012.11:g.122064776delG']['genomic_variant_error'] is None
 		assert 'NM_032790.3' in results['NC_000012.11:g.122064776delG']['hgvs_t_and_p'].keys()
-		assert results['NC_000012.11:g.122064776delG']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] is None
-		assert results['NC_000012.11:g.122064776delG']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] is None
-		assert results['NC_000012.11:g.122064776delG']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] is None
+		assert results['NC_000012.11:g.122064776delG']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] == "NM_032790.3:c.128_129insCCACC"
+		assert results['NC_000012.11:g.122064776delG']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] == "NP_116179.2:p.(Pro44HisfsTer22)"
+		assert results['NC_000012.11:g.122064776delG']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] == "NP_116179.2:p.(P44Hfs*22)"
 		assert results['NC_000012.11:g.122064776delG']['hgvs_t_and_p']['NM_032790.3']['transcript_variant_error'] is None
 
 
@@ -372,9 +372,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000012.11:g.122064776dupG']['g_hgvs'] == 'NC_000012.11:g.122064776dup'
 		assert results['NC_000012.11:g.122064776dupG']['genomic_variant_error'] is None
 		assert 'NM_032790.3' in results['NC_000012.11:g.122064776dupG']['hgvs_t_and_p'].keys()
-		assert results['NC_000012.11:g.122064776dupG']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] is None
-		assert results['NC_000012.11:g.122064776dupG']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] is None
-		assert results['NC_000012.11:g.122064776dupG']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] is None
+		assert results['NC_000012.11:g.122064776dupG']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] == "NM_032790.3:c.129_130insGCCACCG"
+		assert results['NC_000012.11:g.122064776dupG']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] == "NP_116179.2:p.(Pro44AlafsTer46)"
+		assert results['NC_000012.11:g.122064776dupG']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] == "NP_116179.2:p.(P44Afs*46)"
 		assert results['NC_000012.11:g.122064776dupG']['hgvs_t_and_p']['NM_032790.3']['transcript_variant_error'] is None
 
 
@@ -389,9 +389,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000012.11:g.122064776_122064777insTTT']['g_hgvs'] == 'NC_000012.11:g.122064776_122064777insTTT'
 		assert results['NC_000012.11:g.122064776_122064777insTTT']['genomic_variant_error'] is None
 		assert 'NM_032790.3' in results['NC_000012.11:g.122064776_122064777insTTT']['hgvs_t_and_p'].keys()
-		assert results['NC_000012.11:g.122064776_122064777insTTT']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] is None
-		assert results['NC_000012.11:g.122064776_122064777insTTT']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] is None
-		assert results['NC_000012.11:g.122064776_122064777insTTT']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] is None
+		assert results['NC_000012.11:g.122064776_122064777insTTT']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] == "NM_032790.3:c.129_130insTTTCCACCG"
+		assert results['NC_000012.11:g.122064776_122064777insTTT']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] == "NP_116179.2:p.(Pro43_Pro44insPheProPro)"
+		assert results['NC_000012.11:g.122064776_122064777insTTT']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] == "NP_116179.2:p.(P43_P44insFPP)"
 		assert results['NC_000012.11:g.122064776_122064777insTTT']['hgvs_t_and_p']['NM_032790.3']['transcript_variant_error'] is None
 
 
@@ -406,9 +406,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000012.11:g.122064772_122064775del']['g_hgvs'] == 'NC_000012.11:g.122064772_122064775del'
 		assert results['NC_000012.11:g.122064772_122064775del']['genomic_variant_error'] is None
 		assert 'NM_032790.3' in results['NC_000012.11:g.122064772_122064775del']['hgvs_t_and_p'].keys()
-		assert results['NC_000012.11:g.122064772_122064775del']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] is None
-		assert results['NC_000012.11:g.122064772_122064775del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] is None
-		assert results['NC_000012.11:g.122064772_122064775del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] is None
+		assert results['NC_000012.11:g.122064772_122064775del']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] == "NM_032790.3:c.125_126delinsGCCA"
+		assert results['NC_000012.11:g.122064772_122064775del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] == "NP_116179.2:p.(Ala42GlyfsTer23)"
+		assert results['NC_000012.11:g.122064772_122064775del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] == "NP_116179.2:p.(A42Gfs*23)"
 		assert results['NC_000012.11:g.122064772_122064775del']['hgvs_t_and_p']['NM_032790.3']['transcript_variant_error'] is None
 
 
@@ -423,9 +423,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000012.11:g.122064772_122064775dup']['g_hgvs'] == 'NC_000012.11:g.122064772_122064775dup'
 		assert results['NC_000012.11:g.122064772_122064775dup']['genomic_variant_error'] is None
 		assert 'NM_032790.3' in results['NC_000012.11:g.122064772_122064775dup']['hgvs_t_and_p'].keys()
-		assert results['NC_000012.11:g.122064772_122064775dup']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] is None
-		assert results['NC_000012.11:g.122064772_122064775dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] is None
-		assert results['NC_000012.11:g.122064772_122064775dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] is None
+		assert results['NC_000012.11:g.122064772_122064775dup']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] == "NM_032790.3:c.128_129insCCCCGCCACC"
+		assert results['NC_000012.11:g.122064772_122064775dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] == "NP_116179.2:p.(Pro45AlafsTer46)"
+		assert results['NC_000012.11:g.122064772_122064775dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] == "NP_116179.2:p.(P45Afs*46)"
 		assert results['NC_000012.11:g.122064772_122064775dup']['hgvs_t_and_p']['NM_032790.3']['transcript_variant_error'] is None
 
 
@@ -440,9 +440,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000012.11:g.122064773_122064774insTTTT']['g_hgvs'] == 'NC_000012.11:g.122064773_122064774insTTTT'
 		assert results['NC_000012.11:g.122064773_122064774insTTTT']['genomic_variant_error'] is None
 		assert 'NM_032790.3' in results['NC_000012.11:g.122064773_122064774insTTTT']['hgvs_t_and_p'].keys()
-		assert results['NC_000012.11:g.122064773_122064774insTTTT']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] is None
-		assert results['NC_000012.11:g.122064773_122064774insTTTT']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] is None
-		assert results['NC_000012.11:g.122064773_122064774insTTTT']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] is None
+		assert results['NC_000012.11:g.122064773_122064774insTTTT']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] == "NM_032790.3:c.126_127insTTTTCCGCCA"
+		assert results['NC_000012.11:g.122064773_122064774insTTTT']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] == "NP_116179.2:p.(Pro43PhefsTer48)"
+		assert results['NC_000012.11:g.122064773_122064774insTTTT']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] == "NP_116179.2:p.(P43Ffs*48)"
 		assert results['NC_000012.11:g.122064773_122064774insTTTT']['hgvs_t_and_p']['NM_032790.3']['transcript_variant_error'] is None
 
 
@@ -457,9 +457,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000012.11:g.122064772_122064777del']['g_hgvs'] == 'NC_000012.11:g.122064773_122064778del'
 		assert results['NC_000012.11:g.122064772_122064777del']['genomic_variant_error'] is None
 		assert 'NM_032790.3' in results['NC_000012.11:g.122064772_122064777del']['hgvs_t_and_p'].keys()
-		assert results['NC_000012.11:g.122064772_122064777del']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] is None
-		assert results['NC_000012.11:g.122064772_122064777del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] is None
-		assert results['NC_000012.11:g.122064772_122064777del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] is None
+		assert results['NC_000012.11:g.122064772_122064777del']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] == "NM_032790.3:c.126C>A"
+		assert results['NC_000012.11:g.122064772_122064777del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] == "NP_116179.2:p.(Ala42=)"
+		assert results['NC_000012.11:g.122064772_122064777del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] == "NP_116179.2:p.(A42=)"
 		assert results['NC_000012.11:g.122064772_122064777del']['hgvs_t_and_p']['NM_032790.3']['transcript_variant_error'] is None
 
 
@@ -474,9 +474,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000012.11:g.122064772_122064777dup']['g_hgvs'] == 'NC_000012.11:g.122064773_122064778dup'
 		assert results['NC_000012.11:g.122064772_122064777dup']['genomic_variant_error'] is None
 		assert 'NM_032790.3' in results['NC_000012.11:g.122064772_122064777dup']['hgvs_t_and_p'].keys()
-		assert results['NC_000012.11:g.122064772_122064777dup']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] is None
-		assert results['NC_000012.11:g.122064772_122064777dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] is None
-		assert results['NC_000012.11:g.122064772_122064777dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] is None
+		assert results['NC_000012.11:g.122064772_122064777dup']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] == "NM_032790.3:c.131_132insCCCGCCACCGCC"
+		assert results['NC_000012.11:g.122064772_122064777dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] == "NP_116179.2:p.(Pro44_Pro47dup)"
+		assert results['NC_000012.11:g.122064772_122064777dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] == "NP_116179.2:p.(P44_P47dup)"
 		assert results['NC_000012.11:g.122064772_122064777dup']['hgvs_t_and_p']['NM_032790.3']['transcript_variant_error'] is None
 
 
@@ -491,9 +491,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000012.11:g.122064779_122064782dup']['g_hgvs'] == 'NC_000012.11:g.122064779_122064782dup'
 		assert results['NC_000012.11:g.122064779_122064782dup']['genomic_variant_error'] is None
 		assert 'NM_032790.3' in results['NC_000012.11:g.122064779_122064782dup']['hgvs_t_and_p'].keys()
-		assert results['NC_000012.11:g.122064779_122064782dup']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] is None
-		assert results['NC_000012.11:g.122064779_122064782dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] is None
-		assert results['NC_000012.11:g.122064779_122064782dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] is None
+		assert results['NC_000012.11:g.122064779_122064782dup']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] == "NM_032790.3:c.135_136insACCGCCACCG"
+		assert results['NC_000012.11:g.122064779_122064782dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] == "NP_116179.2:p.(Pro46ThrfsTer45)"
+		assert results['NC_000012.11:g.122064779_122064782dup']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] == "NP_116179.2:p.(P46Tfs*45)"
 		assert results['NC_000012.11:g.122064779_122064782dup']['hgvs_t_and_p']['NM_032790.3']['transcript_variant_error'] is None
 
 
@@ -508,9 +508,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000012.11:g.122064772_122064782del']['g_hgvs'] == 'NC_000012.11:g.122064774_122064784del'
 		assert results['NC_000012.11:g.122064772_122064782del']['genomic_variant_error'] is None
 		assert 'NM_032790.3' in results['NC_000012.11:g.122064772_122064782del']['hgvs_t_and_p'].keys()
-		assert results['NC_000012.11:g.122064772_122064782del']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] is None
-		assert results['NC_000012.11:g.122064772_122064782del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] is None
-		assert results['NC_000012.11:g.122064772_122064782del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] is None
+		assert results['NC_000012.11:g.122064772_122064782del']['hgvs_t_and_p']['NM_032790.3']['t_hgvs'] == "NM_032790.3:c.126_127insA"
+		assert results['NC_000012.11:g.122064772_122064782del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_tlc'] == "NP_116179.2:p.(Pro43ThrfsTer45)"
+		assert results['NC_000012.11:g.122064772_122064782del']['hgvs_t_and_p']['NM_032790.3']['p_hgvs_slc'] == "NP_116179.2:p.(P43Tfs*45)"
 		assert results['NC_000012.11:g.122064772_122064782del']['hgvs_t_and_p']['NM_032790.3']['transcript_variant_error'] is None
 
 
@@ -724,9 +724,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000004.11:g.140811111_140811117del']['hgvs_t_and_p']['NM_018717.5']['p_hgvs_slc'] == 'NP_061187.3:p.(Q491Hfs*29)'
 		assert results['NC_000004.11:g.140811111_140811117del']['hgvs_t_and_p']['NM_018717.5']['transcript_variant_error'] is None
 		assert 'NM_018717.4' in results['NC_000004.11:g.140811111_140811117del']['hgvs_t_and_p'].keys()
-		assert results['NC_000004.11:g.140811111_140811117del']['hgvs_t_and_p']['NM_018717.4']['t_hgvs'] is None
-		assert results['NC_000004.11:g.140811111_140811117del']['hgvs_t_and_p']['NM_018717.4']['p_hgvs_tlc'] is None
-		assert results['NC_000004.11:g.140811111_140811117del']['hgvs_t_and_p']['NM_018717.4']['p_hgvs_slc'] is None
+		assert results['NC_000004.11:g.140811111_140811117del']['hgvs_t_and_p']['NM_018717.4']['t_hgvs'] == "NM_018717.4:c.1468_1472dup"
+		assert results['NC_000004.11:g.140811111_140811117del']['hgvs_t_and_p']['NM_018717.4']['p_hgvs_tlc'] == "NP_061187.2:p.(Gln491HisfsTer29)"
+		assert results['NC_000004.11:g.140811111_140811117del']['hgvs_t_and_p']['NM_018717.4']['p_hgvs_slc'] == "NP_061187.2:p.(Q491Hfs*29)"
 		assert results['NC_000004.11:g.140811111_140811117del']['hgvs_t_and_p']['NM_018717.4']['transcript_variant_error'] is None
 
 
@@ -746,9 +746,9 @@ class TestVariantsAuto(object):
 		assert results['NC_000004.11:g.140811117C>A']['hgvs_t_and_p']['NM_018717.5']['p_hgvs_slc'] == 'NP_061187.3:p.(Q491H)'
 		assert results['NC_000004.11:g.140811117C>A']['hgvs_t_and_p']['NM_018717.5']['transcript_variant_error'] is None
 		assert 'NM_018717.4' in results['NC_000004.11:g.140811117C>A']['hgvs_t_and_p'].keys()
-		assert results['NC_000004.11:g.140811117C>A']['hgvs_t_and_p']['NM_018717.4']['t_hgvs'] is None
-		assert results['NC_000004.11:g.140811117C>A']['hgvs_t_and_p']['NM_018717.4']['p_hgvs_tlc'] is None
-		assert results['NC_000004.11:g.140811117C>A']['hgvs_t_and_p']['NM_018717.4']['p_hgvs_slc'] is None
+		assert results['NC_000004.11:g.140811117C>A']['hgvs_t_and_p']['NM_018717.4']['t_hgvs'] == "NM_018717.4:c.1472_1473insTCAGCAGCAGCA"
+		assert results['NC_000004.11:g.140811117C>A']['hgvs_t_and_p']['NM_018717.4']['p_hgvs_tlc'] == "NP_061187.2:p.(Gln490_Gln491insHisGlnGlnGln)"
+		assert results['NC_000004.11:g.140811117C>A']['hgvs_t_and_p']['NM_018717.4']['p_hgvs_slc'] == "NP_061187.2:p.(Q490_Q491insHQQQ)"
 		assert results['NC_000004.11:g.140811117C>A']['hgvs_t_and_p']['NM_018717.4']['transcript_variant_error'] is None
 
 
@@ -828,9 +828,9 @@ class TestVariantsAuto(object):
 
 		assert 'NC_012920.1:m.1011C>T' in results.keys()
 		assert results['NC_012920.1:m.1011C>T']['p_vcf'] == 'M:1011:C:T'
-		assert results['NC_012920.1:m.1011C>T']['g_hgvs'] == 'NC_012920.1:g.1011C>T'
+		assert results['NC_012920.1:m.1011C>T']['g_hgvs'] == 'NC_012920.1:m.1011C>T'
 		assert results['NC_012920.1:m.1011C>T']['genomic_variant_error'] is None
-		assert results['NC_012920.1:m.1011C>T']['hgvs_t_and_p'] is None
+		assert results['NC_012920.1:m.1011C>T']['hgvs_t_and_p'] == {'intergenic': {'alt_genomic_loci': None}}
 
 
 	def test_variant43(self):
@@ -897,8 +897,8 @@ class TestVariantsAuto(object):
 		assert results['NC_000005.9:g.35058667_35058668AG=']['hgvs_t_and_p']['NM_001204316.1']['transcript_variant_error'] is None
 		assert 'NR_037910.1' in results['NC_000005.9:g.35058667_35058668AG=']['hgvs_t_and_p'].keys()
 		assert results['NC_000005.9:g.35058667_35058668AG=']['hgvs_t_and_p']['NR_037910.1']['t_hgvs'] == 'NR_037910.1:n.828-9155_828-9154='
-		assert results['NC_000005.9:g.35058667_35058668AG=']['hgvs_t_and_p']['NR_037910.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['NC_000005.9:g.35058667_35058668AG=']['hgvs_t_and_p']['NR_037910.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['NC_000005.9:g.35058667_35058668AG=']['hgvs_t_and_p']['NR_037910.1']['p_hgvs_tlc'] is None
+		assert results['NC_000005.9:g.35058667_35058668AG=']['hgvs_t_and_p']['NR_037910.1']['p_hgvs_slc'] is None
 		assert results['NC_000005.9:g.35058667_35058668AG=']['hgvs_t_and_p']['NR_037910.1']['transcript_variant_error'] is None
 		assert 'NM_001204318.1' in results['NC_000005.9:g.35058667_35058668AG=']['hgvs_t_and_p'].keys()
 		assert results['NC_000005.9:g.35058667_35058668AG=']['hgvs_t_and_p']['NM_001204318.1']['t_hgvs'] == 'NM_001204318.1:c.686-9155_686-9154='
@@ -1222,8 +1222,8 @@ class TestVariantsAuto(object):
 		assert results['20-43252915-T-C']['hgvs_t_and_p']['NM_001322050.1']['transcript_variant_error'] is None
 		assert 'NR_136160.1' in results['20-43252915-T-C']['hgvs_t_and_p'].keys()
 		assert results['20-43252915-T-C']['hgvs_t_and_p']['NR_136160.1']['t_hgvs'] == 'NR_136160.1:n.685A>G'
-		assert results['20-43252915-T-C']['hgvs_t_and_p']['NR_136160.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['20-43252915-T-C']['hgvs_t_and_p']['NR_136160.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['20-43252915-T-C']['hgvs_t_and_p']['NR_136160.1']['p_hgvs_tlc'] is None
+		assert results['20-43252915-T-C']['hgvs_t_and_p']['NR_136160.1']['p_hgvs_slc'] is None
 		assert results['20-43252915-T-C']['hgvs_t_and_p']['NR_136160.1']['transcript_variant_error'] is None
 		assert 'NM_000022.3' in results['20-43252915-T-C']['hgvs_t_and_p'].keys()
 		assert results['20-43252915-T-C']['hgvs_t_and_p']['NM_000022.3']['t_hgvs'] == 'NM_000022.3:c.534A>G'
@@ -1301,8 +1301,8 @@ class TestVariantsAuto(object):
 		assert results['NC_000005.9:g.35058665_35058666CA=']['hgvs_t_and_p']['NM_001204316.1']['transcript_variant_error'] is None
 		assert 'NR_037910.1' in results['NC_000005.9:g.35058665_35058666CA=']['hgvs_t_and_p'].keys()
 		assert results['NC_000005.9:g.35058665_35058666CA=']['hgvs_t_and_p']['NR_037910.1']['t_hgvs'] == 'NR_037910.1:n.828-9153_828-9152='
-		assert results['NC_000005.9:g.35058665_35058666CA=']['hgvs_t_and_p']['NR_037910.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['NC_000005.9:g.35058665_35058666CA=']['hgvs_t_and_p']['NR_037910.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['NC_000005.9:g.35058665_35058666CA=']['hgvs_t_and_p']['NR_037910.1']['p_hgvs_tlc'] is None
+		assert results['NC_000005.9:g.35058665_35058666CA=']['hgvs_t_and_p']['NR_037910.1']['p_hgvs_slc'] is None
 		assert results['NC_000005.9:g.35058665_35058666CA=']['hgvs_t_and_p']['NR_037910.1']['transcript_variant_error'] is None
 		assert 'NM_001204318.1' in results['NC_000005.9:g.35058665_35058666CA=']['hgvs_t_and_p'].keys()
 		assert results['NC_000005.9:g.35058665_35058666CA=']['hgvs_t_and_p']['NM_001204318.1']['t_hgvs'] == 'NM_001204318.1:c.686-9153_686-9152='
@@ -1425,25 +1425,15 @@ class TestVariantsAuto(object):
 		assert results['15-72105928-AC-ATT']['g_hgvs'] == 'NC_000015.9:g.72105929delinsTT'
 		assert results['15-72105928-AC-ATT']['genomic_variant_error'] is None
 		assert 'NM_014249.3' in results['15-72105928-AC-ATT']['hgvs_t_and_p'].keys()
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.3']['t_hgvs'] is None
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.3']['p_hgvs_tlc'] is None
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.3']['p_hgvs_slc'] is None
+		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.3']['t_hgvs'] == "NM_014249.3:c.947_948insTT"
+		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.3']['p_hgvs_tlc'] == "NP_055064.1:p.(Pro317SerfsTer8)"
+		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.3']['p_hgvs_slc'] == "NP_055064.1:p.(P317Sfs*8)"
 		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.3']['transcript_variant_error'] is None
 		assert 'NM_014249.2' in results['15-72105928-AC-ATT']['hgvs_t_and_p'].keys()
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.2']['t_hgvs'] is None
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.2']['p_hgvs_tlc'] is None
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.2']['p_hgvs_slc'] is None
+		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.2']['t_hgvs'] == "NM_014249.2:c.947_948insTT"
+		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.2']['p_hgvs_tlc'] == "NP_055064.1:p.(Pro317SerfsTer8)"
+		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.2']['p_hgvs_slc'] == "NP_055064.1:p.(P317Sfs*8)"
 		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_014249.2']['transcript_variant_error'] is None
-		assert 'NM_016346.3' in results['15-72105928-AC-ATT']['hgvs_t_and_p'].keys()
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_016346.3']['t_hgvs'] is None
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_016346.3']['p_hgvs_tlc'] is None
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_016346.3']['p_hgvs_slc'] is None
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_016346.3']['transcript_variant_error'] is None
-		assert 'NM_016346.2' in results['15-72105928-AC-ATT']['hgvs_t_and_p'].keys()
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_016346.2']['t_hgvs'] is None
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_016346.2']['p_hgvs_tlc'] is None
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_016346.2']['p_hgvs_slc'] is None
-		assert results['15-72105928-AC-ATT']['hgvs_t_and_p']['NM_016346.2']['transcript_variant_error'] is None
 
 
 	def test_variant67(self):
@@ -1457,25 +1447,15 @@ class TestVariantsAuto(object):
 		assert results['15-72105928-ACC-ATT']['g_hgvs'] == 'NC_000015.9:g.72105929_72105930delinsTT'
 		assert results['15-72105928-ACC-ATT']['genomic_variant_error'] is None
 		assert 'NM_014249.3' in results['15-72105928-ACC-ATT']['hgvs_t_and_p'].keys()
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.3']['t_hgvs'] is None
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.3']['p_hgvs_tlc'] is None
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.3']['p_hgvs_slc'] is None
+		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.3']['t_hgvs'] == "NM_014249.3:c.947_948insTT"
+		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.3']['p_hgvs_tlc'] == "NP_055064.1:p.(Pro317SerfsTer8)"
+		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.3']['p_hgvs_slc'] == "NP_055064.1:p.(P317Sfs*8)"
 		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.3']['transcript_variant_error'] is None
 		assert 'NM_014249.2' in results['15-72105928-ACC-ATT']['hgvs_t_and_p'].keys()
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.2']['t_hgvs'] is None
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.2']['p_hgvs_tlc'] is None
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.2']['p_hgvs_slc'] is None
+		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.2']['t_hgvs'] == "NM_014249.2:c.947_948insTT"
+		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.2']['p_hgvs_tlc'] == "NP_055064.1:p.(Pro317SerfsTer8)"
+		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.2']['p_hgvs_slc'] == "NP_055064.1:p.(P317Sfs*8)"
 		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_014249.2']['transcript_variant_error'] is None
-		assert 'NM_016346.3' in results['15-72105928-ACC-ATT']['hgvs_t_and_p'].keys()
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_016346.3']['t_hgvs'] is None
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_016346.3']['p_hgvs_tlc'] is None
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_016346.3']['p_hgvs_slc'] is None
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_016346.3']['transcript_variant_error'] is None
-		assert 'NM_016346.2' in results['15-72105928-ACC-ATT']['hgvs_t_and_p'].keys()
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_016346.2']['t_hgvs'] is None
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_016346.2']['p_hgvs_tlc'] is None
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_016346.2']['p_hgvs_slc'] is None
-		assert results['15-72105928-ACC-ATT']['hgvs_t_and_p']['NM_016346.2']['transcript_variant_error'] is None
 
 
 	def test_variant68(self):
@@ -1645,8 +1625,8 @@ class TestVariantsAuto(object):
 		assert results['1-5935162-A-T']['hgvs_t_and_p']['NM_001291593.1']['transcript_variant_error'] is None
 		assert 'NR_111987.1' in results['1-5935162-A-T']['hgvs_t_and_p'].keys()
 		assert results['1-5935162-A-T']['hgvs_t_and_p']['NR_111987.1']['t_hgvs'] == 'NR_111987.1:n.3633-2T>A'
-		assert results['1-5935162-A-T']['hgvs_t_and_p']['NR_111987.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['1-5935162-A-T']['hgvs_t_and_p']['NR_111987.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['1-5935162-A-T']['hgvs_t_and_p']['NR_111987.1']['p_hgvs_tlc'] is None
+		assert results['1-5935162-A-T']['hgvs_t_and_p']['NR_111987.1']['p_hgvs_slc'] is None
 		assert results['1-5935162-A-T']['hgvs_t_and_p']['NR_111987.1']['transcript_variant_error'] is None
 		assert 'NM_015102.4' in results['1-5935162-A-T']['hgvs_t_and_p'].keys()
 		assert results['1-5935162-A-T']['hgvs_t_and_p']['NM_015102.4']['t_hgvs'] == 'NM_015102.4:c.2818-2T>A'
@@ -1771,19 +1751,19 @@ class TestVariantsAuto(object):
 		assert results['1-145597475-GAAGT-G']['g_hgvs'] == 'NC_000001.10:g.145597477_145597480del'
 		assert results['1-145597475-GAAGT-G']['genomic_variant_error'] is None
 		assert 'NM_006468.7' in results['1-145597475-GAAGT-G']['hgvs_t_and_p'].keys()
-		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.7']['t_hgvs'] is None
-		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.7']['p_hgvs_tlc'] is None
-		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.7']['p_hgvs_slc'] is None
+		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.7']['t_hgvs'] == "NM_006468.7:c.1070+35_1070+38del"
+		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.7']['p_hgvs_tlc'] == "NP_006459.3:p.?"
+		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.7']['p_hgvs_slc'] == "NP_006459.3:p.?"
 		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.7']['transcript_variant_error'] is None
 		assert 'NM_006468.6' in results['1-145597475-GAAGT-G']['hgvs_t_and_p'].keys()
-		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.6']['t_hgvs'] is None
-		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.6']['p_hgvs_tlc'] is None
-		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.6']['p_hgvs_slc'] is None
+		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.6']['t_hgvs'] == "NM_006468.6:c.1070+35_1070+38del"
+		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.6']['p_hgvs_tlc'] == "NP_006459.3:p.?"
+		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.6']['p_hgvs_slc'] == "NP_006459.3:p.?"
 		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_006468.6']['transcript_variant_error'] is None
 		assert 'NM_001303456.1' in results['1-145597475-GAAGT-G']['hgvs_t_and_p'].keys()
-		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_001303456.1']['t_hgvs'] is None
-		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_001303456.1']['p_hgvs_tlc'] is None
-		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_001303456.1']['p_hgvs_slc'] is None
+		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_001303456.1']['t_hgvs'] == "NM_001303456.1:c.1109+35_1109+38del"
+		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_001303456.1']['p_hgvs_tlc'] == "NP_001290385.1:p.?"
+		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_001303456.1']['p_hgvs_slc'] == "NP_001290385.1:p.?"
 		assert results['1-145597475-GAAGT-G']['hgvs_t_and_p']['NM_001303456.1']['transcript_variant_error'] is None
 
 
@@ -2008,8 +1988,8 @@ class TestVariantsAuto(object):
 		assert results['11-62457852-C-A']['hgvs_t_and_p']['NM_001122955.3']['transcript_variant_error'] is None
 		assert 'NR_037946.1' in results['11-62457852-C-A']['hgvs_t_and_p'].keys()
 		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037946.1']['t_hgvs'] == 'NR_037946.1:n.3896G>T'
-		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037946.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037946.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037946.1']['p_hgvs_tlc'] is None
+		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037946.1']['p_hgvs_slc'] is None
 		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037946.1']['transcript_variant_error'] is None
 		assert 'NM_032667.6' in results['11-62457852-C-A']['hgvs_t_and_p'].keys()
 		assert results['11-62457852-C-A']['hgvs_t_and_p']['NM_032667.6']['t_hgvs'] == 'NM_032667.6:c.1184G>T'
@@ -2023,13 +2003,13 @@ class TestVariantsAuto(object):
 		assert results['11-62457852-C-A']['hgvs_t_and_p']['NM_001130702.2']['transcript_variant_error'] is None
 		assert 'NR_037949.1' in results['11-62457852-C-A']['hgvs_t_and_p'].keys()
 		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037949.1']['t_hgvs'] == 'NR_037949.1:n.1984G>T'
-		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037949.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037949.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037949.1']['p_hgvs_tlc'] is None
+		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037949.1']['p_hgvs_slc'] is None
 		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037949.1']['transcript_variant_error'] is None
 		assert 'NR_037948.1' in results['11-62457852-C-A']['hgvs_t_and_p'].keys()
 		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037948.1']['t_hgvs'] == 'NR_037948.1:n.1978G>T'
-		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037948.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037948.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037948.1']['p_hgvs_tlc'] is None
+		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037948.1']['p_hgvs_slc'] is None
 		assert results['11-62457852-C-A']['hgvs_t_and_p']['NR_037948.1']['transcript_variant_error'] is None
 
 
@@ -2066,106 +2046,20 @@ class TestVariantsAuto(object):
 		assert results['11-111735981-G-A']['g_hgvs'] == 'NC_000011.9:g.111735981G>A'
 		assert results['11-111735981-G-A']['genomic_variant_error'] is None
 		assert 'NM_001352422.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352422.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352422.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352422.1']['p_hgvs_slc'] is None
+		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352422.1']['t_hgvs'] == "NM_001352422.1:c.-326-7C>T"
+		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352422.1']['p_hgvs_tlc'] == "NP_001339351.1:p.?"
+		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352422.1']['p_hgvs_slc'] == "NP_001339351.1:p.?"
 		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352422.1']['transcript_variant_error'] is None
 		assert 'NM_001352415.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352415.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352415.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352415.1']['p_hgvs_slc'] is None
+		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352415.1']['t_hgvs'] == "NM_001352415.1:c.-108-7C>T"
+		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352415.1']['p_hgvs_tlc'] == "NP_001339344.1:p.?"
+		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352415.1']['p_hgvs_slc'] == "NP_001339344.1:p.?"
 		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352415.1']['transcript_variant_error'] is None
 		assert 'NM_001352410.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352410.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352410.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352410.1']['p_hgvs_slc'] is None
+		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352410.1']['t_hgvs'] == "NM_001352410.1:c.-108-7C>T"
+		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352410.1']['p_hgvs_tlc'] == "NP_001339339.1:p.?"
+		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352410.1']['p_hgvs_slc'] == "NP_001339339.1:p.?"
 		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352410.1']['transcript_variant_error'] is None
-		assert 'NM_001352411.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352411.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352411.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352411.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352411.1']['transcript_variant_error'] is None
-		assert 'NM_001077692.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077692.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077692.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077692.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077692.1']['transcript_variant_error'] is None
-		assert 'NR_147984.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NR_147984.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NR_147984.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NR_147984.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NR_147984.1']['transcript_variant_error'] is None
-		assert 'NM_001352423.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352423.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352423.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352423.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352423.1']['transcript_variant_error'] is None
-		assert 'NM_001352414.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352414.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352414.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352414.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352414.1']['transcript_variant_error'] is None
-		assert 'NM_001352420.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352420.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352420.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352420.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352420.1']['transcript_variant_error'] is None
-		assert 'NM_001352416.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352416.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352416.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352416.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352416.1']['transcript_variant_error'] is None
-		assert 'NM_001352417.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352417.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352417.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352417.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352417.1']['transcript_variant_error'] is None
-		assert 'NM_024740.2' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_024740.2']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_024740.2']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_024740.2']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_024740.2']['transcript_variant_error'] is None
-		assert 'NM_001352413.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352413.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352413.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352413.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352413.1']['transcript_variant_error'] is None
-		assert 'NM_001077690.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077690.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077690.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077690.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077690.1']['transcript_variant_error'] is None
-		assert 'NM_001077691.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077691.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077691.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077691.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001077691.1']['transcript_variant_error'] is None
-		assert 'NM_001352412.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352412.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352412.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352412.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352412.1']['transcript_variant_error'] is None
-		assert 'NM_001352418.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352418.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352418.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352418.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352418.1']['transcript_variant_error'] is None
-		assert 'NM_001352409.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352409.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352409.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352409.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352409.1']['transcript_variant_error'] is None
-		assert 'NM_001352419.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352419.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352419.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352419.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352419.1']['transcript_variant_error'] is None
-		assert 'NM_001352421.1' in results['11-111735981-G-A']['hgvs_t_and_p'].keys()
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352421.1']['t_hgvs'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352421.1']['p_hgvs_tlc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352421.1']['p_hgvs_slc'] is None
-		assert results['11-111735981-G-A']['hgvs_t_and_p']['NM_001352421.1']['transcript_variant_error'] is None
-
 
 	def test_variant90(self):
 		variant = '12-11023080-C-A'
@@ -2179,8 +2073,8 @@ class TestVariantsAuto(object):
 		assert results['12-11023080-C-A']['genomic_variant_error'] is None
 		assert 'NR_037918.2' in results['12-11023080-C-A']['hgvs_t_and_p'].keys()
 		assert results['12-11023080-C-A']['hgvs_t_and_p']['NR_037918.2']['t_hgvs'] == 'NR_037918.2:n.1184+11736G>T'
-		assert results['12-11023080-C-A']['hgvs_t_and_p']['NR_037918.2']['p_hgvs_tlc'] == 'non-coding'
-		assert results['12-11023080-C-A']['hgvs_t_and_p']['NR_037918.2']['p_hgvs_slc'] == 'non-coding'
+		assert results['12-11023080-C-A']['hgvs_t_and_p']['NR_037918.2']['p_hgvs_tlc'] is None
+		assert results['12-11023080-C-A']['hgvs_t_and_p']['NR_037918.2']['p_hgvs_slc'] is None
 		assert results['12-11023080-C-A']['hgvs_t_and_p']['NR_037918.2']['transcript_variant_error'] is None
 
 
@@ -2281,9 +2175,9 @@ class TestVariantsAuto(object):
 		assert results['12-103311124-T-C']['hgvs_t_and_p']['NM_000277.1']['p_hgvs_slc'] == 'NP_000268.1:p.?'
 		assert results['12-103311124-T-C']['hgvs_t_and_p']['NM_000277.1']['transcript_variant_error'] is None
 		assert 'NM_001354304.1' in results['12-103311124-T-C']['hgvs_t_and_p'].keys()
-		assert results['12-103311124-T-C']['hgvs_t_and_p']['NM_001354304.1']['t_hgvs'] is None
-		assert results['12-103311124-T-C']['hgvs_t_and_p']['NM_001354304.1']['p_hgvs_tlc'] is None
-		assert results['12-103311124-T-C']['hgvs_t_and_p']['NM_001354304.1']['p_hgvs_slc'] is None
+		assert results['12-103311124-T-C']['hgvs_t_and_p']['NM_001354304.1']['t_hgvs'] == "NM_001354304.1:c.-95-121A>G"
+		assert results['12-103311124-T-C']['hgvs_t_and_p']['NM_001354304.1']['p_hgvs_tlc'] == "NP_001341233.1:p.?"
+		assert results['12-103311124-T-C']['hgvs_t_and_p']['NM_001354304.1']['p_hgvs_slc'] == "NP_001341233.1:p.?"
 		assert results['12-103311124-T-C']['hgvs_t_and_p']['NM_001354304.1']['transcript_variant_error'] is None
 
 
@@ -2334,8 +2228,8 @@ class TestVariantsAuto(object):
 		assert results['12-111064166-G-A']['hgvs_t_and_p']['NM_001173975.2']['transcript_variant_error'] is None
 		assert 'NR_135088.1' in results['12-111064166-G-A']['hgvs_t_and_p'].keys()
 		assert results['12-111064166-G-A']['hgvs_t_and_p']['NR_135088.1']['t_hgvs'] == 'NR_135088.1:n.559-1G>A'
-		assert results['12-111064166-G-A']['hgvs_t_and_p']['NR_135088.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['12-111064166-G-A']['hgvs_t_and_p']['NR_135088.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['12-111064166-G-A']['hgvs_t_and_p']['NR_135088.1']['p_hgvs_tlc'] is None
+		assert results['12-111064166-G-A']['hgvs_t_and_p']['NR_135088.1']['p_hgvs_slc'] is None
 		assert results['12-111064166-G-A']['hgvs_t_and_p']['NR_135088.1']['transcript_variant_error'] is None
 		assert 'NM_001319682.1' in results['12-111064166-G-A']['hgvs_t_and_p'].keys()
 		assert results['12-111064166-G-A']['hgvs_t_and_p']['NM_001319682.1']['t_hgvs'] == 'NM_001319682.1:c.174-1G>A'
@@ -2415,8 +2309,8 @@ class TestVariantsAuto(object):
 		assert results['14-62187287-G-A']['hgvs_t_and_p']['NM_181054.2']['transcript_variant_error'] is None
 		assert 'NR_144368.1' in results['14-62187287-G-A']['hgvs_t_and_p'].keys()
 		assert results['14-62187287-G-A']['hgvs_t_and_p']['NR_144368.1']['t_hgvs'] == 'NR_144368.1:n.214-3552C>T'
-		assert results['14-62187287-G-A']['hgvs_t_and_p']['NR_144368.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['14-62187287-G-A']['hgvs_t_and_p']['NR_144368.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['14-62187287-G-A']['hgvs_t_and_p']['NR_144368.1']['p_hgvs_tlc'] is None
+		assert results['14-62187287-G-A']['hgvs_t_and_p']['NR_144368.1']['p_hgvs_slc'] is None
 		assert results['14-62187287-G-A']['hgvs_t_and_p']['NR_144368.1']['transcript_variant_error'] is None
 		assert 'NM_001530.3' in results['14-62187287-G-A']['hgvs_t_and_p'].keys()
 		assert results['14-62187287-G-A']['hgvs_t_and_p']['NM_001530.3']['t_hgvs'] == 'NM_001530.3:c.223G>A'
@@ -2447,8 +2341,8 @@ class TestVariantsAuto(object):
 		assert results['14-62188231-TT-GA']['hgvs_t_and_p']['NM_181054.2']['transcript_variant_error'] is None
 		assert 'NR_144368.1' in results['14-62188231-TT-GA']['hgvs_t_and_p'].keys()
 		assert results['14-62188231-TT-GA']['hgvs_t_and_p']['NR_144368.1']['t_hgvs'] == 'NR_144368.1:n.214-4497_214-4496delinsTC'
-		assert results['14-62188231-TT-GA']['hgvs_t_and_p']['NR_144368.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['14-62188231-TT-GA']['hgvs_t_and_p']['NR_144368.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['14-62188231-TT-GA']['hgvs_t_and_p']['NR_144368.1']['p_hgvs_tlc'] is None
+		assert results['14-62188231-TT-GA']['hgvs_t_and_p']['NR_144368.1']['p_hgvs_slc'] is None
 		assert results['14-62188231-TT-GA']['hgvs_t_and_p']['NR_144368.1']['transcript_variant_error'] is None
 		assert 'NM_001530.3' in results['14-62188231-TT-GA']['hgvs_t_and_p'].keys()
 		assert results['14-62188231-TT-GA']['hgvs_t_and_p']['NM_001530.3']['t_hgvs'] == 'NM_001530.3:c.231_232delinsGA'
@@ -3441,8 +3335,8 @@ class TestVariantsAuto(object):
 		assert results['17-41197588-GGACA-G']['hgvs_t_and_p']['NM_007298.3']['transcript_variant_error'] is None
 		assert 'NR_027676.1' in results['17-41197588-GGACA-G']['hgvs_t_and_p'].keys()
 		assert results['17-41197588-GGACA-G']['hgvs_t_and_p']['NR_027676.1']['t_hgvs'] == 'NR_027676.1:n.5831_5834del'
-		assert results['17-41197588-GGACA-G']['hgvs_t_and_p']['NR_027676.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['17-41197588-GGACA-G']['hgvs_t_and_p']['NR_027676.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['17-41197588-GGACA-G']['hgvs_t_and_p']['NR_027676.1']['p_hgvs_tlc'] is None
+		assert results['17-41197588-GGACA-G']['hgvs_t_and_p']['NR_027676.1']['p_hgvs_slc'] is None
 		assert results['17-41197588-GGACA-G']['hgvs_t_and_p']['NR_027676.1']['transcript_variant_error'] is None
 		assert 'NM_007297.3' in results['17-41197588-GGACA-G']['hgvs_t_and_p'].keys()
 		assert results['17-41197588-GGACA-G']['hgvs_t_and_p']['NM_007297.3']['t_hgvs'] == 'NM_007297.3:c.*103_*106del'
@@ -3483,8 +3377,8 @@ class TestVariantsAuto(object):
 		assert results['17-41256884-C-G']['hgvs_t_and_p']['NM_007298.3']['transcript_variant_error'] is None
 		assert 'NR_027676.1' in results['17-41256884-C-G']['hgvs_t_and_p'].keys()
 		assert results['17-41256884-C-G']['hgvs_t_and_p']['NR_027676.1']['t_hgvs'] == 'NR_027676.1:n.440+1G>C'
-		assert results['17-41256884-C-G']['hgvs_t_and_p']['NR_027676.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['17-41256884-C-G']['hgvs_t_and_p']['NR_027676.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['17-41256884-C-G']['hgvs_t_and_p']['NR_027676.1']['p_hgvs_tlc'] is None
+		assert results['17-41256884-C-G']['hgvs_t_and_p']['NR_027676.1']['p_hgvs_slc'] is None
 		assert results['17-41256884-C-G']['hgvs_t_and_p']['NR_027676.1']['transcript_variant_error'] is None
 		assert 'NM_007297.3' in results['17-41256884-C-G']['hgvs_t_and_p'].keys()
 		assert results['17-41256884-C-G']['hgvs_t_and_p']['NM_007297.3']['t_hgvs'] == 'NM_007297.3:c.160+1G>C'
@@ -3552,8 +3446,8 @@ class TestVariantsAuto(object):
 		assert results['17-48252809-A-T']['hgvs_t_and_p']['NM_001135697.1']['transcript_variant_error'] is None
 		assert 'NR_135553.1' in results['17-48252809-A-T']['hgvs_t_and_p'].keys()
 		assert results['17-48252809-A-T']['hgvs_t_and_p']['NR_135553.1']['t_hgvs'] == 'NR_135553.1:n.1022A>T'
-		assert results['17-48252809-A-T']['hgvs_t_and_p']['NR_135553.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['17-48252809-A-T']['hgvs_t_and_p']['NR_135553.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['17-48252809-A-T']['hgvs_t_and_p']['NR_135553.1']['p_hgvs_tlc'] is None
+		assert results['17-48252809-A-T']['hgvs_t_and_p']['NR_135553.1']['p_hgvs_slc'] is None
 		assert results['17-48252809-A-T']['hgvs_t_and_p']['NR_135553.1']['transcript_variant_error'] is None
 		assert 'NM_000023.3' in results['17-48252809-A-T']['hgvs_t_and_p'].keys()
 		assert results['17-48252809-A-T']['hgvs_t_and_p']['NM_000023.3']['t_hgvs'] == 'NM_000023.3:c.*11A>T'
@@ -3721,7 +3615,7 @@ class TestVariantsAuto(object):
 		assert results['19-15311794-A-G']['p_vcf'] == '19-15311794-A-G'
 		assert results['19-15311794-A-G']['g_hgvs'] == 'NC_000019.9:g.15311794A>G'
 		assert results['19-15311794-A-G']['genomic_variant_error'] is None
-		assert results['19-15311794-A-G']['hgvs_t_and_p'] is None
+		assert results['19-15311794-A-G']['hgvs_t_and_p'] == {'intergenic': {'alt_genomic_loci': None}}
 
 
 	def test_variant138(self):
@@ -4198,8 +4092,8 @@ class TestVariantsAuto(object):
 		assert results['2-166929889-GTCCAGGTCCT-GAC']['hgvs_t_and_p']['NM_006920.5']['transcript_variant_error'] is None
 		assert 'NR_148667.1' in results['2-166929889-GTCCAGGTCCT-GAC']['hgvs_t_and_p'].keys()
 		assert results['2-166929889-GTCCAGGTCCT-GAC']['hgvs_t_and_p']['NR_148667.1']['t_hgvs'] == 'NR_148667.1:n.638_647delinsGT'
-		assert results['2-166929889-GTCCAGGTCCT-GAC']['hgvs_t_and_p']['NR_148667.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['2-166929889-GTCCAGGTCCT-GAC']['hgvs_t_and_p']['NR_148667.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['2-166929889-GTCCAGGTCCT-GAC']['hgvs_t_and_p']['NR_148667.1']['p_hgvs_tlc'] is None
+		assert results['2-166929889-GTCCAGGTCCT-GAC']['hgvs_t_and_p']['NR_148667.1']['p_hgvs_slc'] is None
 		assert results['2-166929889-GTCCAGGTCCT-GAC']['hgvs_t_and_p']['NR_148667.1']['transcript_variant_error'] is None
 		assert 'NM_001165963.1' in results['2-166929889-GTCCAGGTCCT-GAC']['hgvs_t_and_p'].keys()
 		assert results['2-166929889-GTCCAGGTCCT-GAC']['hgvs_t_and_p']['NM_001165963.1']['t_hgvs'] == 'NM_001165963.1:c.233_242delinsGT'
@@ -4310,8 +4204,8 @@ class TestVariantsAuto(object):
 		assert results['2-166929891-CCAGGTCCT-C']['hgvs_t_and_p']['NM_006920.5']['transcript_variant_error'] is None
 		assert 'NR_148667.1' in results['2-166929891-CCAGGTCCT-C']['hgvs_t_and_p'].keys()
 		assert results['2-166929891-CCAGGTCCT-C']['hgvs_t_and_p']['NR_148667.1']['t_hgvs'] == 'NR_148667.1:n.638_645del'
-		assert results['2-166929891-CCAGGTCCT-C']['hgvs_t_and_p']['NR_148667.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['2-166929891-CCAGGTCCT-C']['hgvs_t_and_p']['NR_148667.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['2-166929891-CCAGGTCCT-C']['hgvs_t_and_p']['NR_148667.1']['p_hgvs_tlc'] is None
+		assert results['2-166929891-CCAGGTCCT-C']['hgvs_t_and_p']['NR_148667.1']['p_hgvs_slc'] is None
 		assert results['2-166929891-CCAGGTCCT-C']['hgvs_t_and_p']['NR_148667.1']['transcript_variant_error'] is None
 		assert 'NM_001165963.1' in results['2-166929891-CCAGGTCCT-C']['hgvs_t_and_p'].keys()
 		assert results['2-166929891-CCAGGTCCT-C']['hgvs_t_and_p']['NM_001165963.1']['t_hgvs'] == 'NM_001165963.1:c.233_240del'
@@ -4387,8 +4281,8 @@ class TestVariantsAuto(object):
 		assert results['2-179393504-G-T']['hgvs_t_and_p']['NM_133378.4']['transcript_variant_error'] is None
 		assert 'NR_038272.1' in results['2-179393504-G-T']['hgvs_t_and_p'].keys()
 		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038272.1']['t_hgvs'] == 'NR_038272.1:n.219+5141G>T'
-		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038272.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038272.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038272.1']['p_hgvs_tlc'] is None
+		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038272.1']['p_hgvs_slc'] is None
 		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038272.1']['transcript_variant_error'] is None
 		assert 'NM_003319.4' in results['2-179393504-G-T']['hgvs_t_and_p'].keys()
 		assert results['2-179393504-G-T']['hgvs_t_and_p']['NM_003319.4']['t_hgvs'] == 'NM_003319.4:c.79779C>A'
@@ -4397,8 +4291,8 @@ class TestVariantsAuto(object):
 		assert results['2-179393504-G-T']['hgvs_t_and_p']['NM_003319.4']['transcript_variant_error'] is None
 		assert 'NR_038271.1' in results['2-179393504-G-T']['hgvs_t_and_p'].keys()
 		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038271.1']['t_hgvs'] == 'NR_038271.1:n.446+5141G>T'
-		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038271.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038271.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038271.1']['p_hgvs_tlc'] is None
+		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038271.1']['p_hgvs_slc'] is None
 		assert results['2-179393504-G-T']['hgvs_t_and_p']['NR_038271.1']['transcript_variant_error'] is None
 		assert 'NM_133432.3' in results['2-179393504-G-T']['hgvs_t_and_p'].keys()
 		assert results['2-179393504-G-T']['hgvs_t_and_p']['NM_133432.3']['t_hgvs'] == 'NM_133432.3:c.80154C>A'
@@ -4522,8 +4416,8 @@ class TestVariantsAuto(object):
 		assert results['22-30064360-G-GCGACGC']['hgvs_t_and_p']['NM_181831.2']['transcript_variant_error'] is None
 		assert 'NR_156186.1' in results['22-30064360-G-GCGACGC']['hgvs_t_and_p'].keys()
 		assert results['22-30064360-G-GCGACGC']['hgvs_t_and_p']['NR_156186.1']['t_hgvs'] == 'NR_156186.1:n.1483_1484insCGACGC'
-		assert results['22-30064360-G-GCGACGC']['hgvs_t_and_p']['NR_156186.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['22-30064360-G-GCGACGC']['hgvs_t_and_p']['NR_156186.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['22-30064360-G-GCGACGC']['hgvs_t_and_p']['NR_156186.1']['p_hgvs_tlc'] is None
+		assert results['22-30064360-G-GCGACGC']['hgvs_t_and_p']['NR_156186.1']['p_hgvs_slc'] is None
 		assert results['22-30064360-G-GCGACGC']['hgvs_t_and_p']['NR_156186.1']['transcript_variant_error'] is None
 		assert 'NM_181829.2' in results['22-30064360-G-GCGACGC']['hgvs_t_and_p'].keys()
 		assert results['22-30064360-G-GCGACGC']['hgvs_t_and_p']['NM_181829.2']['t_hgvs'] == 'NM_181829.2:c.801_802insCGACGC'
@@ -4606,8 +4500,8 @@ class TestVariantsAuto(object):
 		assert results['3-50402127-T-G']['hgvs_t_and_p']['NM_001291101.1']['transcript_variant_error'] is None
 		assert 'NR_111912.1' in results['3-50402127-T-G']['hgvs_t_and_p'].keys()
 		assert results['3-50402127-T-G']['hgvs_t_and_p']['NR_111912.1']['t_hgvs'] == 'NR_111912.1:n.443-1601T>G'
-		assert results['3-50402127-T-G']['hgvs_t_and_p']['NR_111912.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['3-50402127-T-G']['hgvs_t_and_p']['NR_111912.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['3-50402127-T-G']['hgvs_t_and_p']['NR_111912.1']['p_hgvs_tlc'] is None
+		assert results['3-50402127-T-G']['hgvs_t_and_p']['NR_111912.1']['p_hgvs_slc'] is None
 		assert results['3-50402127-T-G']['hgvs_t_and_p']['NR_111912.1']['transcript_variant_error'] is None
 		assert 'NM_001005505.2' in results['3-50402127-T-G']['hgvs_t_and_p'].keys()
 		assert results['3-50402127-T-G']['hgvs_t_and_p']['NM_001005505.2']['t_hgvs'] == 'NM_001005505.2:c.3408A>C'
@@ -4658,8 +4552,8 @@ class TestVariantsAuto(object):
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NM_001174051.2']['transcript_variant_error'] is None
 		assert 'NR_111914.1' in results['3-50402890-G-A']['hgvs_t_and_p'].keys()
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111914.1']['t_hgvs'] == 'NR_111914.1:n.126G>A'
-		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111914.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111914.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111914.1']['p_hgvs_tlc'] is None
+		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111914.1']['p_hgvs_slc'] is None
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111914.1']['transcript_variant_error'] is None
 		assert 'NM_001291101.1' in results['3-50402890-G-A']['hgvs_t_and_p'].keys()
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NM_001291101.1']['t_hgvs'] == 'NM_001291101.1:c.2788C>T'
@@ -4668,8 +4562,8 @@ class TestVariantsAuto(object):
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NM_001291101.1']['transcript_variant_error'] is None
 		assert 'NR_111912.1' in results['3-50402890-G-A']['hgvs_t_and_p'].keys()
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111912.1']['t_hgvs'] == 'NR_111912.1:n.443-838G>A'
-		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111912.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111912.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111912.1']['p_hgvs_tlc'] is None
+		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111912.1']['p_hgvs_slc'] is None
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111912.1']['transcript_variant_error'] is None
 		assert 'NM_001005505.2' in results['3-50402890-G-A']['hgvs_t_and_p'].keys()
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NM_001005505.2']['t_hgvs'] == 'NM_001005505.2:c.2995C>T'
@@ -4683,8 +4577,8 @@ class TestVariantsAuto(object):
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NM_001174051.1']['transcript_variant_error'] is None
 		assert 'NR_111913.1' in results['3-50402890-G-A']['hgvs_t_and_p'].keys()
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111913.1']['t_hgvs'] == 'NR_111913.1:n.126G>A'
-		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111913.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111913.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111913.1']['p_hgvs_tlc'] is None
+		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111913.1']['p_hgvs_slc'] is None
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NR_111913.1']['transcript_variant_error'] is None
 		assert 'NM_001005505.1' in results['3-50402890-G-A']['hgvs_t_and_p'].keys()
 		assert results['3-50402890-G-A']['hgvs_t_and_p']['NM_001005505.1']['t_hgvs'] == 'NM_001005505.1:c.2995C>T'
@@ -4814,7 +4708,7 @@ class TestVariantsAuto(object):
 		assert results['5-1295183-G-A']['p_vcf'] == '5-1295183-G-A'
 		assert results['5-1295183-G-A']['g_hgvs'] == 'NC_000005.9:g.1295183G>A'
 		assert results['5-1295183-G-A']['genomic_variant_error'] is None
-		assert results['5-1295183-G-A']['hgvs_t_and_p'] is None
+		assert results['5-1295183-G-A']['hgvs_t_and_p'] == {'intergenic': {'alt_genomic_loci': None}}
 
 
 	def test_variant159(self):
@@ -4940,8 +4834,8 @@ class TestVariantsAuto(object):
 		assert results['5-131705587-CG-C']['genomic_variant_error'] is None
 		assert 'NR_110997.1' in results['5-131705587-CG-C']['hgvs_t_and_p'].keys()
 		assert results['5-131705587-CG-C']['hgvs_t_and_p']['NR_110997.1']['t_hgvs'] == 'NR_110997.1:n.21del'
-		assert results['5-131705587-CG-C']['hgvs_t_and_p']['NR_110997.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['5-131705587-CG-C']['hgvs_t_and_p']['NR_110997.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['5-131705587-CG-C']['hgvs_t_and_p']['NR_110997.1']['p_hgvs_tlc'] is None
+		assert results['5-131705587-CG-C']['hgvs_t_and_p']['NR_110997.1']['p_hgvs_slc'] is None
 		assert results['5-131705587-CG-C']['hgvs_t_and_p']['NR_110997.1']['transcript_variant_error'] is None
 		assert 'NM_001308122.1' in results['5-131705587-CG-C']['hgvs_t_and_p'].keys()
 		assert results['5-131705587-CG-C']['hgvs_t_and_p']['NM_001308122.1']['t_hgvs'] == 'NM_001308122.1:c.-75del'
@@ -5082,13 +4976,13 @@ class TestVariantsAuto(object):
 		assert results['7-6026775-T-C']['hgvs_t_and_p']['NM_001322011.1']['transcript_variant_error'] is None
 		assert 'NR_136154.1' in results['7-6026775-T-C']['hgvs_t_and_p'].keys()
 		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_136154.1']['t_hgvs'] == 'NR_136154.1:n.1708A>G'
-		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_136154.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_136154.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_136154.1']['p_hgvs_tlc'] is None
+		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_136154.1']['p_hgvs_slc'] is None
 		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_136154.1']['transcript_variant_error'] is None
 		assert 'NR_003085.2' in results['7-6026775-T-C']['hgvs_t_and_p'].keys()
 		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_003085.2']['t_hgvs'] == 'NR_003085.2:n.1703='
-		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_003085.2']['p_hgvs_tlc'] == 'non-coding'
-		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_003085.2']['p_hgvs_slc'] == 'non-coding'
+		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_003085.2']['p_hgvs_tlc'] is None
+		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_003085.2']['p_hgvs_slc'] is None
 		assert results['7-6026775-T-C']['hgvs_t_and_p']['NR_003085.2']['transcript_variant_error'] is None
 		assert 'NM_001322015.1' in results['7-6026775-T-C']['hgvs_t_and_p'].keys()
 		assert results['7-6026775-T-C']['hgvs_t_and_p']['NM_001322015.1']['t_hgvs'] == 'NM_001322015.1:c.1312A>G'
@@ -5241,8 +5135,8 @@ class TestVariantsAuto(object):
 		assert results['7-55248992-T-TTCCAGGAAGCCT']['hgvs_t_and_p']['NM_001346900.1']['transcript_variant_error'] is None
 		assert 'NR_047551.1' in results['7-55248992-T-TTCCAGGAAGCCT']['hgvs_t_and_p'].keys()
 		assert results['7-55248992-T-TTCCAGGAAGCCT']['hgvs_t_and_p']['NR_047551.1']['t_hgvs'] == 'NR_047551.1:n.1272_1283dup'
-		assert results['7-55248992-T-TTCCAGGAAGCCT']['hgvs_t_and_p']['NR_047551.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['7-55248992-T-TTCCAGGAAGCCT']['hgvs_t_and_p']['NR_047551.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['7-55248992-T-TTCCAGGAAGCCT']['hgvs_t_and_p']['NR_047551.1']['p_hgvs_tlc'] is None
+		assert results['7-55248992-T-TTCCAGGAAGCCT']['hgvs_t_and_p']['NR_047551.1']['p_hgvs_slc'] is None
 		assert results['7-55248992-T-TTCCAGGAAGCCT']['hgvs_t_and_p']['NR_047551.1']['transcript_variant_error'] is None
 
 
@@ -5302,8 +5196,8 @@ class TestVariantsAuto(object):
 		assert results['7-117199644-ATCT-A']['genomic_variant_error'] is None
 		assert 'NR_149084.1' in results['7-117199644-ATCT-A']['hgvs_t_and_p'].keys()
 		assert results['7-117199644-ATCT-A']['hgvs_t_and_p']['NR_149084.1']['t_hgvs'] == 'NR_149084.1:n.221+1140_221+1142del'
-		assert results['7-117199644-ATCT-A']['hgvs_t_and_p']['NR_149084.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['7-117199644-ATCT-A']['hgvs_t_and_p']['NR_149084.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['7-117199644-ATCT-A']['hgvs_t_and_p']['NR_149084.1']['p_hgvs_tlc'] is None
+		assert results['7-117199644-ATCT-A']['hgvs_t_and_p']['NR_149084.1']['p_hgvs_slc'] is None
 		assert results['7-117199644-ATCT-A']['hgvs_t_and_p']['NR_149084.1']['transcript_variant_error'] is None
 		assert 'NM_000492.3' in results['7-117199644-ATCT-A']['hgvs_t_and_p'].keys()
 		assert results['7-117199644-ATCT-A']['hgvs_t_and_p']['NM_000492.3']['t_hgvs'] == 'NM_000492.3:c.1521_1523del'
@@ -5339,8 +5233,8 @@ class TestVariantsAuto(object):
 		assert results['7-140453136-AC-CT']['hgvs_t_and_p']['NM_004333.4']['transcript_variant_error'] is None
 		assert 'NR_148928.1' in results['7-140453136-AC-CT']['hgvs_t_and_p'].keys()
 		assert results['7-140453136-AC-CT']['hgvs_t_and_p']['NR_148928.1']['t_hgvs'] == 'NR_148928.1:n.2896_2897delinsAG'
-		assert results['7-140453136-AC-CT']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['7-140453136-AC-CT']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['7-140453136-AC-CT']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_tlc'] is None
+		assert results['7-140453136-AC-CT']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_slc'] is None
 		assert results['7-140453136-AC-CT']['hgvs_t_and_p']['NR_148928.1']['transcript_variant_error'] is None
 
 
@@ -5371,8 +5265,8 @@ class TestVariantsAuto(object):
 		assert results['7-140453136-A-T']['hgvs_t_and_p']['NM_004333.4']['transcript_variant_error'] is None
 		assert 'NR_148928.1' in results['7-140453136-A-T']['hgvs_t_and_p'].keys()
 		assert results['7-140453136-A-T']['hgvs_t_and_p']['NR_148928.1']['t_hgvs'] == 'NR_148928.1:n.2897T>A'
-		assert results['7-140453136-A-T']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['7-140453136-A-T']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['7-140453136-A-T']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_tlc'] is None
+		assert results['7-140453136-A-T']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_slc'] is None
 		assert results['7-140453136-A-T']['hgvs_t_and_p']['NR_148928.1']['transcript_variant_error'] is None
 
 
@@ -5403,8 +5297,8 @@ class TestVariantsAuto(object):
 		assert results['7-140453137-C-T']['hgvs_t_and_p']['NM_004333.4']['transcript_variant_error'] is None
 		assert 'NR_148928.1' in results['7-140453137-C-T']['hgvs_t_and_p'].keys()
 		assert results['7-140453137-C-T']['hgvs_t_and_p']['NR_148928.1']['t_hgvs'] == 'NR_148928.1:n.2896G>A'
-		assert results['7-140453137-C-T']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['7-140453137-C-T']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['7-140453137-C-T']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_tlc'] is None
+		assert results['7-140453137-C-T']['hgvs_t_and_p']['NR_148928.1']['p_hgvs_slc'] is None
 		assert results['7-140453137-C-T']['hgvs_t_and_p']['NR_148928.1']['transcript_variant_error'] is None
 
 
@@ -5420,8 +5314,8 @@ class TestVariantsAuto(object):
 		assert results['7-143013488-A-T']['genomic_variant_error'] is None
 		assert 'NR_046453.1' in results['7-143013488-A-T']['hgvs_t_and_p'].keys()
 		assert results['7-143013488-A-T']['hgvs_t_and_p']['NR_046453.1']['t_hgvs'] == 'NR_046453.1:n.267+3A>T'
-		assert results['7-143013488-A-T']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['7-143013488-A-T']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['7-143013488-A-T']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_tlc'] is None
+		assert results['7-143013488-A-T']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_slc'] is None
 		assert results['7-143013488-A-T']['hgvs_t_and_p']['NR_046453.1']['transcript_variant_error'] is None
 		assert 'NM_000083.2' in results['7-143013488-A-T']['hgvs_t_and_p'].keys()
 		assert results['7-143013488-A-T']['hgvs_t_and_p']['NM_000083.2']['t_hgvs'] == 'NM_000083.2:c.180+3A>T'
@@ -5442,8 +5336,8 @@ class TestVariantsAuto(object):
 		assert results['7-143018934-G-A']['genomic_variant_error'] is None
 		assert 'NR_046453.1' in results['7-143018934-G-A']['hgvs_t_and_p'].keys()
 		assert results['7-143018934-G-A']['hgvs_t_and_p']['NR_046453.1']['t_hgvs'] == 'NR_046453.1:n.776G>A'
-		assert results['7-143018934-G-A']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['7-143018934-G-A']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['7-143018934-G-A']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_tlc'] is None
+		assert results['7-143018934-G-A']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_slc'] is None
 		assert results['7-143018934-G-A']['hgvs_t_and_p']['NR_046453.1']['transcript_variant_error'] is None
 		assert 'NM_000083.2' in results['7-143018934-G-A']['hgvs_t_and_p'].keys()
 		assert results['7-143018934-G-A']['hgvs_t_and_p']['NM_000083.2']['t_hgvs'] == 'NM_000083.2:c.689G>A'
@@ -5464,8 +5358,8 @@ class TestVariantsAuto(object):
 		assert results['7-143048771-C-T']['genomic_variant_error'] is None
 		assert 'NR_046453.1' in results['7-143048771-C-T']['hgvs_t_and_p'].keys()
 		assert results['7-143048771-C-T']['hgvs_t_and_p']['NR_046453.1']['t_hgvs'] == 'NR_046453.1:n.2620C>T'
-		assert results['7-143048771-C-T']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['7-143048771-C-T']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['7-143048771-C-T']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_tlc'] is None
+		assert results['7-143048771-C-T']['hgvs_t_and_p']['NR_046453.1']['p_hgvs_slc'] is None
 		assert results['7-143048771-C-T']['hgvs_t_and_p']['NR_046453.1']['transcript_variant_error'] is None
 		assert 'NM_000083.2' in results['7-143048771-C-T']['hgvs_t_and_p'].keys()
 		assert results['7-143048771-C-T']['hgvs_t_and_p']['NM_000083.2']['t_hgvs'] == 'NM_000083.2:c.2680C>T'
@@ -5683,8 +5577,8 @@ class TestVariantsAuto(object):
 		assert results['HG865_PATCH-33547-G-A']['hgvs_t_and_p']['NM_012309.3']['transcript_variant_error'] == 'start or end or both are beyond the bounds of transcript record'
 		assert 'NR_110766.1' in results['HG865_PATCH-33547-G-A']['hgvs_t_and_p'].keys()
 		assert results['HG865_PATCH-33547-G-A']['hgvs_t_and_p']['NR_110766.1']['t_hgvs'] == 'NR_110766.1:n.833+969C>T'
-		assert results['HG865_PATCH-33547-G-A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['HG865_PATCH-33547-G-A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['HG865_PATCH-33547-G-A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_tlc'] is None
+		assert results['HG865_PATCH-33547-G-A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_slc'] is None
 		assert results['HG865_PATCH-33547-G-A']['hgvs_t_and_p']['NR_110766.1']['transcript_variant_error'] is None
 		assert 'NM_133266.3' in results['HG865_PATCH-33547-G-A']['hgvs_t_and_p'].keys()
 		assert results['HG865_PATCH-33547-G-A']['hgvs_t_and_p']['NM_133266.3']['t_hgvs'] == 'NM_133266.3:c.802C>T'
@@ -7125,7 +7019,7 @@ class TestVariantsAuto(object):
 		assert results['NC_000023.11:g.31119227T>G']['p_vcf'] == 'X:31119227:T:G'
 		assert results['NC_000023.11:g.31119227T>G']['g_hgvs'] == 'NC_000023.11:g.31119227T>G'
 		assert results['NC_000023.11:g.31119227T>G']['genomic_variant_error'] is None
-		assert results['NC_000023.11:g.31119227T>G']['hgvs_t_and_p'] is None
+		assert results['NC_000023.11:g.31119227T>G']['hgvs_t_and_p'] == {'intergenic': {'alt_genomic_loci': None}}
 
 
 	def test_variant229(self):
@@ -7138,7 +7032,7 @@ class TestVariantsAuto(object):
 		assert results['NC_000023.11:g.31118748C>A']['p_vcf'] == 'X:31118748:C:A'
 		assert results['NC_000023.11:g.31118748C>A']['g_hgvs'] == 'NC_000023.11:g.31118748C>A'
 		assert results['NC_000023.11:g.31118748C>A']['genomic_variant_error'] is None
-		assert results['NC_000023.11:g.31118748C>A']['hgvs_t_and_p'] is None
+		assert results['NC_000023.11:g.31118748C>A']['hgvs_t_and_p'] == {'intergenic': {'alt_genomic_loci': None}}
 
 
 	def test_variant230(self):
@@ -7163,8 +7057,8 @@ class TestVariantsAuto(object):
 		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NM_012309.4']['transcript_variant_error'] is None
 		assert 'NR_110766.1' in results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p'].keys()
 		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['t_hgvs'] == 'NR_110766.1:n.833+2621A>T'
-		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_tlc'] is None
+		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_slc'] is None
 		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['transcript_variant_error'] is None
 
 
@@ -7190,8 +7084,8 @@ class TestVariantsAuto(object):
 		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NM_012309.4']['transcript_variant_error'] is None
 		assert 'NR_110766.1' in results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p'].keys()
 		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['t_hgvs'] == 'NR_110766.1:n.833+2621A>T'
-		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_tlc'] is None
+		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_slc'] is None
 		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['transcript_variant_error'] is None
 
 
@@ -7249,8 +7143,8 @@ class TestVariantsAuto(object):
 		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NM_012309.4']['transcript_variant_error'] is None
 		assert 'NR_110766.1' in results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p'].keys()
 		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['t_hgvs'] == 'NR_110766.1:n.833+2621A>T'
-		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_tlc'] == 'non-coding'
-		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_slc'] == 'non-coding'
+		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_tlc'] is None
+		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['p_hgvs_slc'] is None
 		assert results['NC_000011.10:g.70487682T>A']['hgvs_t_and_p']['NR_110766.1']['transcript_variant_error'] is None
 
 
@@ -7413,37 +7307,37 @@ class TestVariantsAuto(object):
 		assert results['X-76813149-AT-AATA']['genomic_variant_error'] is None
 		assert 'NR_110406.2' in results['X-76813149-AT-AATA']['hgvs_t_and_p'].keys()
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110406.2']['t_hgvs'] == 'NR_110406.2:n.412-154842delinsTAT'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110406.2']['p_hgvs_tlc'] == 'non-coding'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110406.2']['p_hgvs_slc'] == 'non-coding'
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110406.2']['p_hgvs_tlc'] is None
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110406.2']['p_hgvs_slc'] is None
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110406.2']['transcript_variant_error'] is None
 		assert 'NR_110402.2' in results['X-76813149-AT-AATA']['hgvs_t_and_p'].keys()
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110402.2']['t_hgvs'] == 'NR_110402.2:n.412-120063delinsTAT'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110402.2']['p_hgvs_tlc'] == 'non-coding'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110402.2']['p_hgvs_slc'] == 'non-coding'
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110402.2']['p_hgvs_tlc'] is None
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110402.2']['p_hgvs_slc'] is None
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110402.2']['transcript_variant_error'] is None
 		assert 'NR_110401.2' in results['X-76813149-AT-AATA']['hgvs_t_and_p'].keys()
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110401.2']['t_hgvs'] == 'NR_110401.2:n.412-154482delinsTAT'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110401.2']['p_hgvs_tlc'] == 'non-coding'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110401.2']['p_hgvs_slc'] == 'non-coding'
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110401.2']['p_hgvs_tlc'] is None
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110401.2']['p_hgvs_slc'] is None
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110401.2']['transcript_variant_error'] is None
 		assert 'NR_110404.2' in results['X-76813149-AT-AATA']['hgvs_t_and_p'].keys()
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110404.2']['t_hgvs'] == 'NR_110404.2:n.307-154482delinsTAT'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110404.2']['p_hgvs_tlc'] == 'non-coding'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110404.2']['p_hgvs_slc'] == 'non-coding'
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110404.2']['p_hgvs_tlc'] is None
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110404.2']['p_hgvs_slc'] is None
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110404.2']['transcript_variant_error'] is None
 		assert 'NR_110400.2' in results['X-76813149-AT-AATA']['hgvs_t_and_p'].keys()
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110400.2']['t_hgvs'] == 'NR_110400.2:n.307-120063delinsTAT'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110400.2']['p_hgvs_tlc'] == 'non-coding'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110400.2']['p_hgvs_slc'] == 'non-coding'
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110400.2']['p_hgvs_tlc'] is None
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110400.2']['p_hgvs_slc'] is None
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110400.2']['transcript_variant_error'] is None
 		assert 'NR_110405.2' in results['X-76813149-AT-AATA']['hgvs_t_and_p'].keys()
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110405.2']['t_hgvs'] == 'NR_110405.2:n.307-31858delinsTAT'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110405.2']['p_hgvs_tlc'] == 'non-coding'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110405.2']['p_hgvs_slc'] == 'non-coding'
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110405.2']['p_hgvs_tlc'] is None
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110405.2']['p_hgvs_slc'] is None
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110405.2']['transcript_variant_error'] is None
 		assert 'NR_110403.2' in results['X-76813149-AT-AATA']['hgvs_t_and_p'].keys()
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110403.2']['t_hgvs'] == 'NR_110403.2:n.389+24660delinsTAT'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110403.2']['p_hgvs_tlc'] == 'non-coding'
-		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110403.2']['p_hgvs_slc'] == 'non-coding'
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110403.2']['p_hgvs_tlc'] is None
+		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110403.2']['p_hgvs_slc'] is None
 		assert results['X-76813149-AT-AATA']['hgvs_t_and_p']['NR_110403.2']['transcript_variant_error'] is None
 


### PR DESCRIPTION
…ng and broken tests ensuring the discrepancies reflect the outputs of VV. This makes maintaining the gap mapping code much more manageable. Closes https://github.com/openvar/variantValidator/issues/263. Closes https://github.com/openvar/variantValidator/issues/265.