### PR TITLE
Don't catch HGVS with NG/LRG as VCF

### DIFF
--- a/VariantFormatter/simpleVariantFormatter.py
+++ b/VariantFormatter/simpleVariantFormatter.py
@@ -59,8 +59,13 @@ def format(batch_input, genome_build, transcript_model=None, specify_transcripts
         # Set validation warning flag
         formatted_variants[variant]['flag'] = None
         format_these = []
-        if re.match('chr[\w\d]+-', variant) or re.match('chr[\w\d]+:', variant) or re.match('[\w\d]+-', variant)\
-                or re.match('[\w\d]+:', variant):
+        # specially exclude LRGs as they do not have a "." separated
+        # version number, we don't handle them (yet?) but they are not VCF
+        if not variant.startswith('LRG') and (
+                re.match('chr[\w\d]+-', variant) or
+                re.match('chr[\w\d]+:', variant) or
+                re.match('[\w\d]+-', variant) or
+                re.match('[\w\d]+:', variant)):
             pseudo_vcf = variant
 
             if re.search(':', pseudo_vcf):

--- a/VariantFormatter/variantformatter.py
+++ b/VariantFormatter/variantformatter.py
@@ -250,6 +250,34 @@ class FormatVariant(object):
                 else:
                     gen_error = None
 
+        # Recognise unhandled/bad ref types, this needs to be before VCF handling as
+        # that is a bit of a catch all and will otherwise process HGVS LRG refs as VCF
+        elif (self.variant_description.startswith('NG_')
+              or self.variant_description.startswith('LRG_')):
+            p_vcf = None
+            g_hgvs = None
+            hgvs_ref_bases = None
+            un_norm_hgvs = None
+            gen_error = ('Variant description ' + self.variant_description +
+                         ' uses a reference type that is currently unhandled'+
+                         ' through this tool')
+            if self.variant_description.startswith('NG_'):
+                gen_error = ('Variant description ' + self.variant_description +
+                             ' uses the NG_ reference type, this is currently '+
+                             'not accepted through this tool')
+            elif self.variant_description.startswith('LRG_'):
+                 gen_error = ('Variant description ' + self.variant_description+
+                              ' uses the LRG_ reference type, LRGs are no '+
+                              'longer being updated, and are not recommended, '+
+                              'they are also not currently accepted through '+
+                              'this tool')
+            gds = GenomicDescriptions(
+                    p_vcf, g_hgvs, un_norm_hgvs, hgvs_ref_bases, gen_error,
+                    genome_build, variant_description)
+            self.genomic_descriptions = gds
+            self.warning_level = 'submission_warning'
+            return
+
         # vcf2hgvs route
         elif re.match('chr[\w\d]+\-', self.variant_description) or re.match(
                 'chr[\w\d]+:', self.variant_description) or re.match('[\w\d]+\-', self.variant_description) \


### PR DESCRIPTION
This pull request adds handling for retypes that should be associated with HGVS but which are bad (LRG_ is no longer updated), or not currently handled (NG_). Actually adding handling for these would require a whole lot more work, but users should get informative errors now. Pete please have a look and tell me if it needs more work, or if the error messages would benefit from re-phrasing.